### PR TITLE
Prune negative SEE captures that don't give check in quiesce

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -294,6 +294,12 @@ int quiesce(int alpha, int beta, int ply, Board* board, SearchParams* params, Se
       continue;
 
     makeMove(move, board);
+
+    if (moveList->scores[i] <= 0 && !inCheck(board)) {
+      undoMove(move, board);
+      continue;
+    }
+
     int score = -quiesce(-beta, -alpha, ply + 1, board, params, data);
     undoMove(move, board);
 


### PR DESCRIPTION
```
ELO   | 18.19 +- 9.27 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3136 W: 993 L: 829 D: 1314
```
http://chess.honnold.me/test/26/