### PR TITLE
Hotfix King Safety Evaluation

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -181,7 +181,7 @@ const int PASSED_PAWN[2][8] = {
     },
 };
 
-const int PAWN_SHELTER = 36;
+const int PAWN_SHELTER = -36;
 const int PAWN_STORM[8] = {0, 0, 0, -10, -30, -60, 0, 0};
 
 const int DEFENDED_MINOR = S(5, 2);


### PR DESCRIPTION
This was not inverted as it should have been which lead to awkward calculations
```
ELO   | 7.39 +- 5.39 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10064 W: 3280 L: 3066 D: 3718
```
Bench: 10014198
Test: http://chess.honnold.me/test/50/