### PR TITLE
LMR Updates

### DIFF
--- a/src/movegen.h
+++ b/src/movegen.h
@@ -7,6 +7,13 @@ extern const BitBoard HOME_RANKS[];
 extern const BitBoard THIRD_RANKS[];
 extern const int PAWN_DIRECTIONS[];
 
+extern const int HASH;
+extern const int GOOD_CAPTURE;
+extern const int BAD_CAPTURE;
+extern const int KILLER1;
+extern const int KILLER2;
+extern const int COUNTER;
+
 void addMove(MoveList* moveList, Move move);
 void generateMoves(MoveList* moveList, Board* board, int ply);
 void generateQuiesceMoves(MoveList* moveList, Board* board);

--- a/src/search.c
+++ b/src/search.c
@@ -184,8 +184,6 @@ int negamax(int alpha, int beta, int depth, int ply, int canNull, Board* board, 
     if (depth >= 3 && numMoves > 1 && !moveCapture(move) && !movePromo(move) && !givesCheck && !currInCheck) {
       int R = LMR[min(depth, 63)][min(numMoves, 63)];
 
-      if (!isPV)
-        R++;
       if (moveList->scores[i] >= COUNTER)
         R--;
 

--- a/src/search.c
+++ b/src/search.c
@@ -183,6 +183,12 @@ int negamax(int alpha, int beta, int depth, int ply, int canNull, Board* board, 
     int givesCheck = inCheck(board);
     if (depth >= 3 && numMoves > 1 && !moveCapture(move) && !movePromo(move) && !givesCheck && !currInCheck) {
       int R = LMR[min(depth, 63)][min(numMoves, 63)];
+
+      if (!isPV)
+        R++;
+      if (moveList->scores[i] >= COUNTER)
+        R--;
+
       score = -negamax(-alpha - 1, -alpha, newDepth - R, ply + 1, 1, board, params, data);
       doZws = (score > alpha);
     }

--- a/src/search.c
+++ b/src/search.c
@@ -186,6 +186,8 @@ int negamax(int alpha, int beta, int depth, int ply, int canNull, Board* board, 
 
       if (moveList->scores[i] >= COUNTER)
         R--;
+      if (!isPV && moveList->scores[i] < 50)
+        R++;
 
       score = -negamax(-alpha - 1, -alpha, newDepth - R, ply + 1, 1, board, params, data);
       doZws = (score > alpha);


### PR DESCRIPTION
Less reduction if move is a killer or a counter.
More reduction if non-pv and move score is low. (This does not include -SEE scores as LMR doesn't apply to captures).

```
ELO   | 16.64 +- 8.83 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3552 W: 1146 L: 976 D: 1430
```
http://chess.honnold.me/test/60/