### PR TITLE
King Safety Bugfix

### DIFF
--- a/src/eval.h
+++ b/src/eval.h
@@ -28,6 +28,7 @@ int toScore(EvalData* data);
 int isMaterialDraw(Board* board);
 void EvaluateSide(Board* board, int side, EvalData* data);
 void EvaluateThreats(Board* board, int side, EvalData* data, EvalData* enemyData);
+void EvaluateKingSafety(Board* board, int side, EvalData* data, EvalData* enemyData);
 int Evaluate(Board* board);
 void PrintEvaluation(Board* board);
 

--- a/src/types.h
+++ b/src/types.h
@@ -77,6 +77,8 @@ typedef struct {
 
   int threats;
   BitBoard attacks[6];
+  BitBoard allAttacks;
+  BitBoard attacks2;
 } EvalData;
 
 enum { WHITE, BLACK, BOTH };

--- a/src/types.h
+++ b/src/types.h
@@ -72,10 +72,12 @@ typedef struct {
 
   int mobility;
 
-  int attacking;
   int kingSafety;
 
   int threats;
+
+  int attackers;
+  int attackScore;
   BitBoard attacks[6];
   BitBoard allAttacks;
   BitBoard attacks2;


### PR DESCRIPTION
Attacks are supposed to be calculated only when opponent has Queen + 1. The attacks were being calculated when the given side has Queen + 1. This is incorrect.