### PR TITLE
Improve static eval from Transposition Table

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -127,6 +127,12 @@ int negamax(int alpha, int beta, int depth, int ply, int canNull, Board* board, 
 
   int staticEval = Evaluate(board);
   if (!isPV && !currInCheck) {
+    if (ttValue && ttDepth(ttValue) >= depth) {
+      int ttEval = ttScore(ttValue, ply);
+      if (ttFlag(ttValue) == (ttEval > staticEval ? TT_LOWER : TT_UPPER))
+        staticEval = ttEval;
+    }
+
     // Reverse Futility Pruning
     if (depth <= 6 && staticEval - (FUTILITY_MARGIN * depth) >= beta && staticEval < MATE_BOUND)
       return staticEval;
@@ -283,6 +289,11 @@ int quiesce(int alpha, int beta, int ply, Board* board, SearchParams* params, Se
   }
 
   int eval = Evaluate(board);
+  if (ttValue) {
+    int ttEval = ttScore(ttValue, ply);
+    if (ttFlag(ttValue) == (ttEval > eval ? TT_LOWER : TT_UPPER))
+      eval = ttEval;
+  }
 
   if (eval >= beta)
     return beta;


### PR DESCRIPTION
```
ELO   | 3.83 +- 3.04 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 29856 W: 9058 L: 8729 D: 12069
```
http://chess.honnold.me/test/81/