### PR TITLE
Fix improving calculation and pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -32,11 +32,11 @@ void initLMR() {
       LMR[depth][moves] = (int)(0.6f + log(depth) * log(1.2f * moves) / 2.5f);
 
   for (int depth = 0; depth < 64; depth++) {
-    LMP[0][depth] = 3 + depth * depth;
-    LMP[1][depth] = 3 + depth * depth / 2;
+    LMP[0][depth] = (3 + depth * depth) / 2; // not improving
+    LMP[1][depth] = 3 + depth * depth;
 
-    SEE[0][depth] = SEE_PRUNE_CUTOFF * depth * depth;
-    SEE[1][depth] = SEE_PRUNE_CAPTURE_CUTOFF * depth;
+    SEE[0][depth] = SEE_PRUNE_CUTOFF * depth * depth; // quiet
+    SEE[1][depth] = SEE_PRUNE_CAPTURE_CUTOFF * depth; // capture
 
     FUTILITY[depth] = FUTILITY_MARGIN * depth;
   }

--- a/src/search.c
+++ b/src/search.c
@@ -171,7 +171,7 @@ int negamax(int alpha, int beta, int depth, int ply, int canNull, Board* board, 
   }
 
   data->evals[ply] = staticEval;
-  int improving = ply >= 2 && staticEval <= data->evals[ply - 2];
+  int improving = ply >= 2 && staticEval > data->evals[ply - 2];
 
   MoveList moveList[1];
   generateMoves(moveList, board, ply);


### PR DESCRIPTION
Improving was inverted.

```
ELO   | 34.99 +- 13.43 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1584 W: 563 L: 404 D: 617
```
http://chess.honnold.me/test/104/

Bench: 7689758
