### PR TITLE
Prune negative SEE checks in Quiesce 

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -456,6 +456,7 @@ void nullMove(Board* board) {
   board->castlingHistory[board->moveNo] = board->castling;
   board->epSquareHistory[board->moveNo] = board->epSquare;
   board->captureHistory[board->moveNo] = -1;
+  board->gameMoves[board->moveNo] = NULL_MOVE;
 
   if (board->epSquare)
     board->zobrist ^= ZOBRIST_EP_KEYS[board->epSquare];

--- a/src/move.h
+++ b/src/move.h
@@ -3,6 +3,8 @@
 
 #include "types.h"
 
+#define NULL_MOVE 0
+
 extern const int CHAR_TO_PIECE[];
 extern const char* PIECE_TO_CHAR;
 extern const char* PROMOTION_TO_CHAR;

--- a/src/search.c
+++ b/src/search.c
@@ -326,7 +326,7 @@ int quiesce(int alpha, int beta, int ply, Board* board, SearchParams* params, Se
 
     makeMove(move, board);
 
-    if (moveList->scores[i] <= 0 && !inCheck(board)) {
+    if (moveList->scores[i] < 0) {
       undoMove(move, board);
       continue;
     }

--- a/src/search.c
+++ b/src/search.c
@@ -324,13 +324,10 @@ int quiesce(int alpha, int beta, int ply, Board* board, SearchParams* params, Se
     if (eval + DELTA_CUTOFF + scoreMG(MATERIAL_VALUES[captured]) < alpha)
       continue;
 
+    if (moveList->scores[i] < 0)
+      break;
+
     makeMove(move, board);
-
-    if (moveList->scores[i] < 0) {
-      undoMove(move, board);
-      continue;
-    }
-
     int score = -quiesce(-beta, -alpha, ply + 1, board, params, data);
     undoMove(move, board);
 


### PR DESCRIPTION
```
ELO   | 8.21 +- 5.65 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8208 W: 2418 L: 2224 D: 3566
```
Bench: 6842445
http://chess.honnold.me/test/106/