### PR TITLE
Quiesce Fail Soft

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -305,10 +305,12 @@ int quiesce(int alpha, int beta, int ply, Board* board, SearchParams* params, Se
   }
 
   if (eval >= beta)
-    return beta;
+    return eval;
 
   if (eval > alpha)
     alpha = eval;
+
+  int bestScore = eval;
 
   MoveList moveList[1];
   generateQuiesceMoves(moveList, board);
@@ -334,11 +336,14 @@ int quiesce(int alpha, int beta, int ply, Board* board, SearchParams* params, Se
     if (params->stopped)
       return 0;
 
-    if (score >= beta)
-      return beta;
-    if (score > alpha)
-      alpha = score;
+    if (score > bestScore) {
+      bestScore = score;
+      alpha = max(alpha, score);
+
+      if (alpha >= beta)
+        break;
+    }
   }
 
-  return alpha;
+  return bestScore;
 }


### PR DESCRIPTION
Mostly done for fail-soft consistency throughout search.

```
ELO   | 5.68 +- 6.40 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6480 W: 1910 L: 1804 D: 2766
```
http://chess.honnold.me/test/110/
Bench: 7284178