### PR TITLE
Evaluation Optimization

### DIFF
--- a/src/eval.h
+++ b/src/eval.h
@@ -22,9 +22,9 @@ extern int MATERIAL_AND_PSQT_VALUES[12][64];
 void initPSQT();
 
 int getPhase(Board* board);
-int taper(int score, int phase);
+int taper(int mg, int eg, int phase);
 
-int toScore(EvalData* data);
+int toScore(EvalData* data, Board* board);
 int isMaterialDraw(Board* board);
 void EvaluateSide(Board* board, int side, EvalData* data);
 void EvaluateThreats(Board* board, int side, EvalData* data, EvalData* enemyData);

--- a/src/types.h
+++ b/src/types.h
@@ -66,17 +66,17 @@ typedef struct {
 } SearchParams;
 
 typedef struct {
-  int material;
-  int pawns;
-  int knights;
-  int bishops;
-  int rooks;
-  int queens;
-  int kings;
+  int material[2];
+  int pawns[2];
+  int knights[2];
+  int bishops[2];
+  int rooks[2];
+  int queens[2];
+  int kings[2];
 
-  int mobility;
-  int kingSafety;
-  int threats;
+  int mobility[2];
+  int kingSafety[2];
+  int threats[2];
 
   BitBoard attacks[6];
   BitBoard allAttacks;


### PR DESCRIPTION
This was a long time coming. Taper being per parameter is inefficient. This moves that all to a single calculation.

```
ELO   | 8.46 +- 7.49 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 4808 W: 1459 L: 1342 D: 2007
```
http://chess.honnold.me/test/120/

This did cause changes in the bench due to rounding
Bench: 8623629