### PR TITLE
Prefetch TT during MakeMove

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -24,6 +24,7 @@
 #include "board.h"
 #include "move.h"
 #include "movegen.h"
+#include "transposition.h"
 #include "types.h"
 #include "zobrist.h"
 
@@ -428,6 +429,9 @@ void MakeMove(Move move, Board* board) {
   // special pieces must be loaded after the side has changed
   // this is because the new side to move will be the one in check
   SetSpecialPieces(board);
+
+  // Prefetch the hash entry for this board position
+  TTPrefetch(board->zobrist);
 }
 
 void UndoMove(Move move, Board* board) {
@@ -580,6 +584,9 @@ void MakeNullMove(Board* board) {
   board->moveNo++;
   board->side = board->xside;
   board->xside ^= 1;
+
+  // Prefetch the hash entry for this board position
+  TTPrefetch(board->zobrist);
 }
 
 void UndoNullMove(Board* board) {

--- a/src/search.c
+++ b/src/search.c
@@ -111,7 +111,8 @@ void* Search(void* arg) {
   Move bestMove = threads[0].data.bestMove;
   printf("bestmove %s\n", MoveToStr(bestMove));
 
-  if (args->free) free(args); // this was allocated above, it needs to be free'd to prevent a leak
+  if (args->free)
+    free(args); // this was allocated above, it needs to be free'd to prevent a leak
   return NULL;
 }
 

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -60,6 +60,8 @@ inline int TTScore(TTValue value, int ply) {
   return score > MATE_BOUND ? score - ply : score < -MATE_BOUND ? score + ply : score;
 }
 
+inline void TTPrefetch(uint64_t hash) { __builtin_prefetch(&TRANSPOSITION_ENTRIES[TTIdx(hash)]); }
+
 inline TTValue TTProbe(uint64_t hash) {
 #ifdef TUNE
   return NO_ENTRY;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -39,6 +39,7 @@ extern int POWER;
 void TTInit(int mb);
 void TTFree();
 void TTClear();
+void TTPrefetch(uint64_t hash);
 TTValue TTProbe(uint64_t hash);
 int TTScore(TTValue value, int ply);
 TTValue TTPut(uint64_t hash, int depth, int score, int flag, Move move, int ply, int eval);


### PR DESCRIPTION
```
ELO   | 4.95 +- 4.16 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 11512 W: 2559 L: 2395 D: 6558
```
http://167.114.125.235:8080/test/831/