### PR TITLE
Max Phase cleanup

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -34,6 +34,7 @@
 
 // Phase generation calculation is standard from CPW
 Score PHASE_MULTIPLIERS[5] = {0, 1, 1, 2, 4};
+Score MAX_PHASE = 24;
 
 // static piece values for see and delta pruning just match EG values
 int STATIC_MATERIAL_VALUE[7] = {93, 310, 323, 548, 970, 30000, 0};
@@ -157,29 +158,19 @@ void InitPSQT() {
   }
 }
 
-// TODO: since I don't tune this, probably should just make it 24
-inline Score MaxPhase() {
-  return 4 * PHASE_MULTIPLIERS[KNIGHT_TYPE] + 4 * PHASE_MULTIPLIERS[BISHOP_TYPE] + 4 * PHASE_MULTIPLIERS[ROOK_TYPE] +
-         2 * PHASE_MULTIPLIERS[QUEEN_TYPE];
-}
-
 // game phase is remaing piece phase score / max phase score. So opening is 1, endgame is 0
 inline Score GetPhase(Board* board) {
-  Score maxP = MaxPhase();
-
   Score phase = 0;
   for (int i = KNIGHT_WHITE; i <= QUEEN_BLACK; i++)
     phase += PHASE_MULTIPLIERS[PIECE_TYPE[i]] * bits(board->pieces[i]);
 
-  phase = min(maxP, phase);
+  phase = min(MAX_PHASE, phase);
   return phase;
 }
 
 // combine a mg and eg score to a linearly tapered value
 inline Score Taper(Score mg, Score eg, Score phase) {
-  Score maxP = MaxPhase();
-
-  return (phase * mg + (maxP - phase) * eg) / maxP;
+  return (phase * mg + (MAX_PHASE - phase) * eg) / MAX_PHASE;
 }
 
 // check for all sorts of different piece keys that represent a draw

--- a/src/eval.h
+++ b/src/eval.h
@@ -75,7 +75,6 @@ extern TScore TEMPO;
 
 void InitPSQT();
 
-Score MaxPhase();
 Score GetPhase(Board* board);
 Score Taper(Score mg, Score eg, Score phase);
 


### PR DESCRIPTION
Bench: 8087895

Simplification of calculation of the max phase. It was originally a method in order to support
potential tuning of this value, but that has been abandoned. Replacing this value with a constant
has led to a speedup.

```
ELO   | 4.36 +- 4.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 8520 W: 2003 L: 1896 D: 4621
```
https://chess.honnold.me/test/269/
