### PR TITLE
Increase time spend by 10% if score jumps

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -150,11 +150,20 @@ void* Search(void* arg) {
         delta += delta / 2;
       }
 
+      if (mainThread) {
+        PrintInfo(pv, score, depth, thread);
+
+        // We've set a window, but score is still varying
+        if (depth >= 5 && params->timeset && abs(data->score - score) >= 25) {
+          params->timeToSpend = params->timeToSpend * 110 / 100; // 10% bump
+
+          if (params->startTime + params->timeToSpend <= params->maxTime)
+            params->endTime = params->startTime + params->timeToSpend;
+        }
+      }
+
       data->bestMove = pv->moves[0];
       data->score = score;
-
-      if (mainThread)
-        PrintInfo(pv, score, depth, thread);
     }
   }
 

--- a/src/types.h
+++ b/src/types.h
@@ -109,6 +109,9 @@ typedef struct {
 typedef struct {
   long startTime;
   long endTime;
+  long maxTime;
+  int timeToSpend;
+
   int depth;
   int timeset;
   int movesToGo;

--- a/src/uci.c
+++ b/src/uci.c
@@ -89,12 +89,16 @@ void ParseGo(char* in, SearchParams* params, Board* board, ThreadData* threads) 
       // 1 / movestogo clocktime + inc - 50ms (buffer)
       // TODO: Improve this, most likely in Search
       params->timeset = 1;
-      time /= movesToGo;
-      time += inc;
-      time -= 50; // buffer time
-      params->endTime = params->startTime + time;
+      int timetoSpend = time / movesToGo;
+      timetoSpend += inc;
+      timetoSpend -= 50; // buffer time
+      params->timeToSpend = timetoSpend;
+      params->endTime = params->startTime + timetoSpend;
+      params->maxTime = params->startTime + time / 2 - 50;
     } else {
       params->endTime = 0;
+      params->maxTime = 0;
+      params->timeToSpend = 0;
     }
 
     if (depth <= 0)


### PR DESCRIPTION
Bench: 7854929

```
ELO   | 5.28 +- 4.38 (95%)
SPRT  | 8+0.08s Threads=1 Hash=8MB
LLR   | 3.09 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 11840 W: 2991 L: 2811 D: 6038
```

http://167.114.125.235:8080/test/921/