### PR TITLE
!isPV applies to both captures/quiets

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -351,10 +351,10 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     if (depth >= 2 && numMoves > 1) {
       R = LMR[min(depth, 63)][min(numMoves, 63)];
 
-      if (!tactical) {
-        if (!isPV)
-          R++;
+      if (!isPV)
+        R++;
 
+      if (!tactical) {
         if (!improving)
           R++;
 


### PR DESCRIPTION
Bench: 6986178
```
ELO   | 4.54 +- 3.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 13168 W: 3046 L: 2874 D: 7248
```
https://chess.honnold.me/test/307/