### PR TITLE
Proper hash table usage

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -29,7 +29,6 @@
 // Berserk's transposition table is just a giant array of longs
 // Even indicies store the key, odd indicies story the entry
 // For collisions, conflicting hashes have buckets of size 2
-// TODO: Check to see what happens with bucket size 1 or 4?
 
 // Global TT
 TTValue* TRANSPOSITION_ENTRIES = NULL;
@@ -38,16 +37,18 @@ int POWER = 0;
 
 const TTValue NO_ENTRY = 0ULL;
 
-void TTInit(int mb) {
-  POWER = (int)log2(0x100000 / sizeof(TTValue)) + (int)log2(mb) - (int)log2(BUCKET_SIZE) - 1;
+size_t TTInit(int mb) {
+  POWER = (int)log2(MEGABYTE / sizeof(TTValue)) + (int)log2(mb) - (int)log2(BUCKET_SIZE);
 
   if (TRANSPOSITION_ENTRIES != NULL)
     free(TRANSPOSITION_ENTRIES);
 
-  SIZE = (1ULL << POWER) * sizeof(TTValue) * BUCKET_SIZE * 2;
-  TRANSPOSITION_ENTRIES = malloc(SIZE);
+  SIZE = (1ULL << POWER) * sizeof(TTValue) * BUCKET_SIZE;
+  TRANSPOSITION_ENTRIES = (TTValue*) malloc(SIZE);
 
   TTClear();
+
+  return SIZE;
 }
 
 void TTFree() { free(TRANSPOSITION_ENTRIES); }

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -25,7 +25,8 @@ extern const TTValue NO_ENTRY;
 extern TTValue* TRANSPOSITION_ENTRIES;
 extern int POWER;
 
-#define BUCKET_SIZE 2
+#define MEGABYTE 0x100000ULL
+#define BUCKET_SIZE 2ULL
 
 #define TTIdx(hash) ((uint64_t)((hash) >> (64 - POWER)) << 1)
 #define TTEntry(score, flag, depth, move, eval)                                                                        \
@@ -36,7 +37,7 @@ extern int POWER;
 #define TTDepth(value) ((int)((value)&0x3F000000) >> 24)
 #define TTEval(value) ((int)((int16_t)((value) >> 48)))
 
-void TTInit(int mb);
+size_t TTInit(int mb);
 void TTFree();
 void TTClear();
 void TTPrefetch(uint64_t hash);

--- a/src/uci.c
+++ b/src/uci.c
@@ -231,8 +231,8 @@ void UCILoop() {
     } else if (!strncmp(in, "setoption name Hash value ", 26)) {
       int mb = GetOptionIntValue(in);
       mb = max(4, min(65536, mb));
-      TTInit(mb);
-      printf("info string set Hash to value %d\n", mb);
+      size_t bytesAllocated = TTInit(mb);
+      printf("info string set Hash to value %d (%lld bytes)\n", mb, bytesAllocated);
     } else if (!strncmp(in, "setoption name Threads value ", 29)) {
       int n = GetOptionIntValue(in);
       free(threads);


### PR DESCRIPTION
Bench: 6935550

ELO   | 7.37 +- 10.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.06 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 1792 W: 403 L: 365 D: 1024

https://chess.honnold.me/test/354/