### PR TITLE
Adjust Phase to use 128

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -289,7 +289,7 @@ inline int GetPhase(Board* board) {
     phase += PHASE_MULTIPLIERS[PIECE_TYPE[i]] * bits(board->pieces[i]);
 
   phase = min(MAX_PHASE, phase);
-  return phase;
+  return (phase * 256 + MAX_PHASE / 2) / MAX_PHASE;
 }
 
 // Get a scalar for the given board for the stronger side (out of 100)
@@ -759,12 +759,12 @@ Score Evaluate(Board* board, ThreadData* thread) {
 
   // taper
   int phase = GetPhase(board);
-  s = (phase * scoreMG(s) + (MAX_PHASE - phase) * scoreEG(s)) / MAX_PHASE;
+  Score res = (phase * scoreMG(s) + (256 - phase) * scoreEG(s)) / 256;
 
   if (T)
-    C.ss = s >= 0 ? WHITE : BLACK;
+    C.ss = res >= 0 ? WHITE : BLACK;
 
   // scale the score
-  s = (s * Scale(board, s >= 0 ? WHITE : BLACK) + MAX_SCALE / 2)/ MAX_SCALE;
-  return TEMPO + (board->side == WHITE ? s : -s);
+  res = (res * Scale(board, res >= 0 ? WHITE : BLACK) + MAX_SCALE / 2) / MAX_SCALE;
+  return TEMPO + (board->side == WHITE ? res : -res);
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -289,7 +289,7 @@ inline int GetPhase(Board* board) {
     phase += PHASE_MULTIPLIERS[PIECE_TYPE[i]] * bits(board->pieces[i]);
 
   phase = min(MAX_PHASE, phase);
-  return (phase * 256 + MAX_PHASE / 2) / MAX_PHASE;
+  return (phase * 128 + MAX_PHASE / 2) / MAX_PHASE;
 }
 
 // Get a scalar for the given board for the stronger side (out of 100)
@@ -759,7 +759,7 @@ Score Evaluate(Board* board, ThreadData* thread) {
 
   // taper
   int phase = GetPhase(board);
-  Score res = (phase * scoreMG(s) + (256 - phase) * scoreEG(s)) / 256;
+  Score res = (phase * scoreMG(s) + (128 - phase) * scoreEG(s)) / 128;
 
   if (T)
     C.ss = res >= 0 ? WHITE : BLACK;

--- a/src/pawns.c
+++ b/src/pawns.c
@@ -1,12 +1,11 @@
-#include "attacks.h"
 #include "pawns.h"
+#include "attacks.h"
 #include "bits.h"
 #include "board.h"
 #include "eval.h"
 #include "movegen.h"
 #include "types.h"
 #include "util.h"
-
 
 #ifdef TUNE
 #define T 1
@@ -17,13 +16,13 @@
 extern EvalCoeffs C;
 
 inline PawnHashEntry* TTPawnProbe(uint64_t hash, ThreadData* thread) {
-  return thread->pawnHashTable[(hash & PAWN_TABLE_MASK)].hash == hash ? &thread->pawnHashTable[(hash & PAWN_TABLE_MASK)] : NULL;
+  PawnHashEntry* entry = &thread->pawnHashTable[(hash & PAWN_TABLE_MASK)];
+  return entry->hash == hash ? entry : NULL;
 }
 
 inline void TTPawnPut(uint64_t hash, Score s, BitBoard passedPawns, ThreadData* thread) {
-  thread->pawnHashTable[(hash & PAWN_TABLE_MASK)].hash = hash;
-  thread->pawnHashTable[(hash & PAWN_TABLE_MASK)].s = s;
-  thread->pawnHashTable[(hash & PAWN_TABLE_MASK)].passedPawns = passedPawns;
+  PawnHashEntry* entry = &thread->pawnHashTable[(hash & PAWN_TABLE_MASK)];
+  *entry = (PawnHashEntry){.hash = hash, .s = s, .passedPawns = passedPawns};
 }
 
 // Standard pawn and passer evaluation


### PR DESCRIPTION
This is an ELO hit, but (potentially) prevents bench issues

Bench: 6493406

ELO   | -2.44 +- 1.80 (95%)
SPRT  | 8+0.08s Threads=1 Hash=16MB
LLR   | -2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 62032 W: 13293 L: 13728 D: 35011

http://167.114.125.235:8080/test/1025/