### PR TITLE
Late Move Pruning without "Check" requirement

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -35,7 +35,7 @@ void AddHistoryHeuristic(SearchData* data, Move move, int stm, int inc) {
   *e += 64 * inc - *e * abs(inc) / 1024;
 }
 
-void UpdateHistories(SearchData* data, Move bestMove, int depth, int stm, MoveList* moves, int c) {
+void UpdateHistories(SearchData* data, Move bestMove, int depth, int stm, MoveList* quiets) {
   int inc = min(depth * depth, 576);
   
   if (!Tactical(bestMove)) {
@@ -44,8 +44,7 @@ void UpdateHistories(SearchData* data, Move bestMove, int depth, int stm, MoveLi
     AddHistoryHeuristic(data, bestMove, stm, inc);
   }
 
-  for (int i = 0; i < c; i++) {
-    if (!Tactical(moves->moves[i]))
-      AddHistoryHeuristic(data, moves->moves[i], stm, -inc);
-  }
+  for (int i = 0; i < quiets->count; i++)
+    if (quiets->moves[i] != bestMove)
+      AddHistoryHeuristic(data, quiets->moves[i], stm, -inc);
 }

--- a/src/history.h
+++ b/src/history.h
@@ -22,6 +22,6 @@
 void AddKillerMove(SearchData* data, Move move);
 void AddCounterMove(SearchData* data, Move move, Move parent);
 void AddHistoryHeuristic(SearchData* data, Move move, int stm, int inc);
-void UpdateHistories(SearchData* data, Move bestMove, int depth, int stm, MoveList* moves, int c);
+void UpdateHistories(SearchData* data, Move bestMove, int depth, int stm, MoveList* quiets);
 
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -345,6 +345,9 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
   MoveList moveList;
   GenerateAllMoves(&moveList, board, data);
 
+  MoveList quiets;
+  quiets.count = 0;
+
   int numMoves = 0;
   for (int i = 0; i < moveList.count; i++) {
     ChooseTopMove(&moveList, i);
@@ -368,6 +371,9 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
     if (isRoot && !thread->idx && GetTimeMS() - 2500 >= params->startTime)
       printf("info depth %d currmove %s currmovenumber %d\n", depth, MoveToStr(move), numMoves);
+
+    if (!tactical)
+      quiets.moves[quiets.count++] = move;
 
     // singular extension
     // if one move is better than all the rest, then we consider this singular
@@ -469,7 +475,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
       // we're failing high
       if (alpha >= beta) {
-        UpdateHistories(data, move, depth, board->side, &moveList, i);
+        UpdateHistories(data, move, depth, board->side, &quiets);
         break;
       }
     }

--- a/src/search.c
+++ b/src/search.c
@@ -348,7 +348,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
   MoveList quiets;
   quiets.count = 0;
 
-  int numMoves = 0;
+  int numMoves = 0, searchedMoves = 0;
   for (int i = 0; i < moveList.count; i++) {
     ChooseTopMove(&moveList, i);
     Move move = moveList.moves[i];
@@ -368,6 +368,8 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     // quiet moves use a quadratic scale upwards
     if (!isRoot && bestScore > -MATE_BOUND && SEE(board, move) < STATIC_PRUNE[tactical][depth])
       continue;
+
+    searchedMoves++;
 
     if (isRoot && !thread->idx && GetTimeMS() - 2500 >= params->startTime)
       printf("info depth %d currmove %s currmovenumber %d\n", depth, MoveToStr(move), numMoves);
@@ -417,7 +419,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     // Late move reductions
     int R = 1;
     if (depth > 2 && numMoves > 1) {
-      R = LMR[min(depth, 63)][min(numMoves, 63)];
+      R = LMR[min(depth, 63)][min(searchedMoves, 63)];
 
       if (!tactical) {
         // increase reduction on non-pv

--- a/src/search.c
+++ b/src/search.c
@@ -361,14 +361,14 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
     int tactical = MovePromo(move) || MoveCapture(move);
 
-    if (!isRoot && bestScore > -MATE_BOUND && depth <= 8 && !tactical && totalMoves > LMP[improving][depth])
+    if (bestScore > -MATE_BOUND && depth <= 8 && !tactical && totalMoves > LMP[improving][depth])
       continue;
 
     totalMoves++;
 
     // Static evaluation pruning, this applies for both quiet and tactical moves
     // quiet moves use a quadratic scale upwards
-    if (!isRoot && bestScore > -MATE_BOUND && SEE(board, move) < STATIC_PRUNE[tactical][depth])
+    if (bestScore > -MATE_BOUND && SEE(board, move) < STATIC_PRUNE[tactical][depth])
       continue;
 
     nonPrunedMoves++;


### PR DESCRIPTION
This is a larger merge as it is preparation for phased move generation. Standard move generators tend to filter quiet moves using a single flag. This was not possible for Berserk as it's LMP had a special flag looking for whether the move gave check. This PR removes that requirement and stay about even on Elo. 

Bench: 10603549

ELO   | 1.82 +- 1.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 9.83 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 53436 W: 12292 L: 12012 D: 29132

http://167.114.125.235:8080/test/1331/

*Note: This test was run on [0,5] bounds, but kept once it was holding [-4,1] bounds.*