### PR TITLE
General Speedup from improving Shift

### DIFF
--- a/src/attacks.c
+++ b/src/attacks.c
@@ -160,11 +160,11 @@ BitBoard GetGeneratedPawnAttacks(int sq, int color) {
   setBit(board, sq);
 
   if (color == WHITE) {
-    attacks |= Shift(board, NW);
-    attacks |= Shift(board, NE);
+    attacks |= ShiftNW(board);
+    attacks |= ShiftNE(board);
   } else {
-    attacks |= Shift(board, SE);
-    attacks |= Shift(board, SW);
+    attacks |= ShiftSE(board);
+    attacks |= ShiftSW(board);
   }
 
   return attacks;
@@ -213,14 +213,14 @@ BitBoard GetGeneratedKingAttacks(int sq) {
 
   setBit(board, sq);
 
-  attacks |= Shift(board, N);
-  attacks |= Shift(board, NE);
-  attacks |= Shift(board, E);
-  attacks |= Shift(board, SE);
-  attacks |= Shift(board, S);
-  attacks |= Shift(board, SW);
-  attacks |= Shift(board, W);
-  attacks |= Shift(board, NW);
+  attacks |= ShiftN(board);
+  attacks |= ShiftNE(board);
+  attacks |= ShiftE(board);
+  attacks |= ShiftSE(board);
+  attacks |= ShiftS(board);
+  attacks |= ShiftSW(board);
+  attacks |= ShiftW(board);
+  attacks |= ShiftNW(board);
 
   return attacks;
 }

--- a/src/bits.c
+++ b/src/bits.c
@@ -64,34 +64,6 @@ inline int bits(BitBoard bb) {
 }
 #endif
 
-// Shifts a bitboard in a cardinal direction, with protection against off-the-board problems
-inline BitBoard Shift(BitBoard bb, int dir) {
-  switch (dir) {
-  case N:
-    return bb >> 8;
-  case S:
-    return bb << 8;
-  case (N + N):
-    return bb >> 16;
-  case (S + S):
-    return bb << 16;
-  case W:
-    return (bb & ~A_FILE) >> 1;
-  case E:
-    return (bb & ~H_FILE) << 1;
-  case NE:
-    return (bb & ~H_FILE) >> 7;
-  case SW:
-    return (bb & ~A_FILE) << 7;
-  case NW:
-    return (bb & ~A_FILE) >> 9;
-  case SE:
-    return (bb & ~H_FILE) << 9;
-  default:
-    return 0;
-  }
-}
-
 inline int popAndGetLsb(BitBoard* bb) {
   int sq = lsb(*bb);
   popLsb(*bb);

--- a/src/bits.h
+++ b/src/bits.h
@@ -61,8 +61,18 @@ int bits(BitBoard bb);
 #define bits(bb) (__builtin_popcountll(bb))
 #endif
 
+#define ShiftN(bb) ((bb) >> 8)
+#define ShiftS(bb) ((bb) << 8)
+#define ShiftNN(bb) ((bb) >> 16)
+#define ShiftSS(bb) ((bb) << 16)
+#define ShiftW(bb) (((bb) & ~A_FILE) >> 1)
+#define ShiftE(bb) (((bb) & ~H_FILE) << 1)
+#define ShiftNE(bb) (((bb) & ~H_FILE) >> 7)
+#define ShiftSW(bb) (((bb) & ~A_FILE) << 7)
+#define ShiftNW(bb) (((bb) & ~A_FILE) >> 9)
+#define ShiftSE(bb) (((bb) & ~H_FILE) << 9)
+
 int popAndGetLsb(BitBoard* bb);
-BitBoard Shift(BitBoard bb, int dir);
 BitBoard Fill(BitBoard initial, int direction);
 void PrintBB(BitBoard bb);
 

--- a/src/move.h
+++ b/src/move.h
@@ -40,7 +40,7 @@ extern const char* SQ_TO_COORD[];
 // just mask the start/end bits into a single int for indexing butterfly tables
 #define MoveStartEnd(move) ((move)&0xfff)
 
-#define Tactical(move) (MoveCapture(move) || MovePromo(move))
+#define Tactical(move) (((move)&0x1f0000) >> 16)
 
 Move ParseMove(char* moveStr, Board* board);
 char* MoveToStr(Move move);

--- a/src/pawns.c
+++ b/src/pawns.c
@@ -43,7 +43,7 @@ Score PawnEval(Board* board, EvalData* data, int side) {
     int adjustedRank = side ? 7 - rank : rank;
 
     BitBoard opposed = board->pieces[PAWN[xside]] & FILE_MASKS[file] & FORWARD_RANK_MASKS[side][rank];
-    BitBoard doubled = board->pieces[PAWN[side]] & Shift(bb, PAWN_DIRECTIONS[xside]);
+    BitBoard doubled = board->pieces[PAWN[side]] & (side == WHITE ? ShiftS(bb) : ShiftN(bb));
     BitBoard neighbors = board->pieces[PAWN[side]] & ADJACENT_FILE_MASKS[file];
     BitBoard connected = neighbors & RANK_MASKS[rank];
     BitBoard defenders = board->pieces[PAWN[side]] & GetPawnAttacks(sq, xside);

--- a/src/search.c
+++ b/src/search.c
@@ -362,7 +362,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     if (skipMove == move)
       continue;
 
-    int tactical = MovePromo(move) || MoveCapture(move);
+    int tactical = !!Tactical(move);
 
     if (bestScore > -MATE_BOUND && depth <= 8 && !tactical && totalMoves > LMP[improving][depth])
       continue;


### PR DESCRIPTION
Bench: 11173038

ELO   | 4.27 +- 3.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18068 W: 3979 L: 3757 D: 10332

Apparently spending 3.6% of your time in `Shift` is bad. This was due to the `switch` statement I was using. Now it calls exactly what it wants wherever shift is used to prevent unneeded jumps.