### PR TITLE
Sort Promotion moves using SEE

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -579,7 +579,7 @@ void GenerateAllMoves(MoveList* moveList, Board* board, SearchData* data) {
     if (move == hashMove) {
       moveList->scores[i] = HASH_MOVE_SCORE;
     } else if (MoveEP(move)) {
-      moveList->scores[i] = GOOD_CAPTURE_SCORE + MVV_LVA[PAWN[board->side]][PAWN[board->xside]];
+      moveList->scores[i] = GOOD_CAPTURE_SCORE + MVV_LVA[PAWN_WHITE][PAWN_WHITE];
     } else if (MoveCapture(move)) {
       int mover = MovePiece(move);
       int captured = board->squares[MoveEnd(move)];
@@ -593,8 +593,13 @@ void GenerateAllMoves(MoveList* moveList, Board* board, SearchData* data) {
       } else {
         moveList->scores[i] = GOOD_CAPTURE_SCORE + MVV_LVA[mover][captured];
       }
-    } else if (MovePromo(move) >= 8) {
-      moveList->scores[i] = GOOD_CAPTURE_SCORE + STATIC_MATERIAL_VALUE[QUEEN_TYPE];
+    } else if (MovePromo(move)) {
+      int seeScore = SEE(board, move);
+      if (seeScore < 0) {
+        moveList->scores[i] = BAD_CAPTURE_SCORE + seeScore;
+      } else {
+        moveList->scores[i] = GOOD_CAPTURE_SCORE + MVV_LVA[PAWN_WHITE][MovePromo(move)];
+      }
     } else if (move == data->killers[data->ply][0]) {
       moveList->scores[i] = KILLER1_SCORE;
     } else if (move == data->killers[data->ply][1]) {


### PR DESCRIPTION
Bench: 10217511

ELO   | 1.58 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 4.27 (-2.94, 2.94) [-2.00, 3.00]
Games | N: 52636 W: 11437 L: 11197 D: 30002

Originally tested for gains, but considered a bug so keeping this as it doesn't lose. The bug was that under promotions were sorted in with quiets. This prevents that and sorts them using SEE.