### PR TITLE
Allow faster subtree searches with more local replacements

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -97,7 +97,7 @@ inline void TTPut(uint64_t hash, uint8_t depth, int16_t score, uint8_t flag, Mov
     }
 
     if (entry->hash == shortHash) {
-      if (entry->depth > depth && !(flag & TT_EXACT))
+      if (entry->depth >= depth + 4 && !(flag & TT_EXACT))
         return;
 
       replacementIdx = i;


### PR DESCRIPTION
Bench: 10425723

ELO   | 8.17 +- 5.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7184 W: 1602 L: 1433 D: 4149

Berserk had a strict no-replacement for newly incoming tt entries, with the hash already in the table (under most conditions). In order to allow more localized scores in the TT, this replacement barrier was degraded slightly by allowing a margin of depth to be accounted for.

Thank you to Martin (Author of Cheng) for bringing this to my attention.