### PR TITLE
Null threat 2

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -182,6 +182,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
   Move bestMove = NULL_MOVE;
   Move skipMove = data->skipMove[data->ply]; // skip used in SE (concept from SF)
+  Move nullThreat = NULL_MOVE;
 
   Move move;
   MoveList moves;
@@ -310,6 +311,8 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
       if (score >= beta)
         return beta;
+
+      nullThreat = childPv.count ? childPv.moves[0] : NULL_MOVE;
     }
 
     // Prob cut
@@ -427,6 +430,9 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
         // increase reduction if our eval is declining
         if (!improving)
           R++;
+
+        if (nullThreat && (MoveStart(move) == MoveEnd(nullThreat)))
+          R--;
 
         // decrease reduction if we're looking at a "specific" quiet move
         // killer1, killer2, and counter

--- a/src/search.c
+++ b/src/search.c
@@ -431,8 +431,8 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
         if (!improving)
           R++;
 
-        if (nullThreat && (MoveStart(move) == MoveEnd(nullThreat)))
-          R--;
+        if (MoveCapture(nullThreat) && MoveStart(move) != MoveEnd(nullThreat) && !board->checkers)
+          R++;
 
         // decrease reduction if we're looking at a "specific" quiet move
         // killer1, killer2, and counter


### PR DESCRIPTION
Bench: 9067713

ELO   | 5.07 +- 3.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13508 W: 2991 L: 2794 D: 7723

If the null move fails to a capture, increase reductions of moves that don't give check or avoid the capture.
*Note: This does not account for moves that defend the threatened piece or capture another piece and can potentially be improved upon.*