### PR TITLE
Initial history pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -359,11 +359,15 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
       continue;
 
     int tactical = !!Tactical(move);
+    int moveScore = moves.scores[moves.idx - 1];
 
     if (bestScore > -MATE_BOUND && depth <= 8 && !tactical && totalMoves > LMP[improving][depth])
       continue;
 
     totalMoves++;
+
+    if (bestScore > -MATE_BOUND && !tactical && depth <= 2 && moveScore <= -2048 * depth * depth)
+      continue;
 
     // Static evaluation pruning, this applies for both quiet and tactical moves
     // quiet moves use a quadratic scale upwards
@@ -436,11 +440,11 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
         // decrease reduction if we're looking at a "specific" quiet move
         // killer1, killer2, and counter
-        if (moves.scores[moves.idx - 1] >= COUNTER_SCORE)
+        if (moveScore >= COUNTER_SCORE)
           R--;
 
         // adjust reduction based on historical score
-        R -= moves.scores[moves.idx - 1] / 16384;
+        R -= moveScore / 16384;
       } else {
         R--;
       }


### PR DESCRIPTION
Bench: 11552895

ELO   | 4.64 +- 3.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15136 W: 3226 L: 3024 D: 8886

When a move has a really negative history, prune at a really low depth.