### PR TITLE
Expand king area

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -23,6 +23,7 @@
 
 #define file(sq) ((sq)&7)
 #define rank(sq) ((sq) >> 3)
+#define sq(r, f) ((r) * 8 + (f))
 
 extern const BitBoard EMPTY;
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -334,8 +334,13 @@ void InitEvalData(EvalData* data, Board* board) {
   data->kingSq[WHITE] = lsb(board->pieces[KING_WHITE]);
   data->kingSq[BLACK] = lsb(board->pieces[KING_BLACK]);
 
-  data->kingArea[WHITE] = GetKingAttacks(data->kingSq[WHITE]);
-  data->kingArea[BLACK] = GetKingAttacks(data->kingSq[BLACK]);
+  int whiteKingF = max(1, min(6, file(data->kingSq[WHITE])));
+  int whiteKingR = max(1, min(6, rank(data->kingSq[WHITE])));
+  int blackKingF = max(1, min(6, file(data->kingSq[BLACK])));
+  int blackKingR = max(1, min(6, rank(data->kingSq[BLACK])));
+
+  data->kingArea[WHITE] = GetKingAttacks(sq(whiteKingR, whiteKingF)) | bit(sq(whiteKingR, whiteKingF));
+  data->kingArea[BLACK] = GetKingAttacks(sq(blackKingR, blackKingF)) | bit(sq(blackKingR, blackKingF));
 }
 
 // Material + PSQT value


### PR DESCRIPTION
Bench: 9436705

ELO   | 9.73 +- 6.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6180 W: 1683 L: 1510 D: 2987

Expanding the king area when on the edge of the board allows Berserk to identify/build up attacks that don't have to immediately at the king, but at least in the area.