### PR TITLE
Tuned SEE Values with CTT

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -48,7 +48,7 @@ const int MAX_PHASE = 24;
 const int PHASE_MULTIPLIERS[5] = {0, 1, 1, 2, 4};
 const int MAX_SCALE = 128;
 
-const int STATIC_MATERIAL_VALUE[7] = {100, 540, 540, 675, 1045, 30000, 0};
+const int STATIC_MATERIAL_VALUE[7] = {100, 565, 565, 705, 1000, 30000, 0};
 const int SHELTER_STORM_FILES[8][2] = {{0, 2}, {0, 2}, {1, 3}, {2, 4}, {3, 5}, {4, 6}, {5, 7}, {5, 7}};
 
 // clang-format off

--- a/src/eval.c
+++ b/src/eval.c
@@ -48,7 +48,7 @@ const int MAX_PHASE = 24;
 const int PHASE_MULTIPLIERS[5] = {0, 1, 1, 2, 4};
 const int MAX_SCALE = 128;
 
-const int STATIC_MATERIAL_VALUE[7] = {100, 325, 325, 550, 975, 30000, 0};
+const int STATIC_MATERIAL_VALUE[7] = {100, 540, 540, 675, 1045, 30000, 0};
 const int SHELTER_STORM_FILES[8][2] = {{0, 2}, {0, 2}, {1, 3}, {2, 4}, {3, 5}, {4, 6}, {5, 7}, {5, 7}};
 
 // clang-format off


### PR DESCRIPTION
Bench: 8759604

ELO   | 6.36 +- 4.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9732 W: 2186 L: 2008 D: 5538