### PR TITLE
SEE Cutoff's Tuned

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -32,8 +32,8 @@
 // static evaluation pruning
 // capture cutoff is linear 70x
 // quiet cutoff is quadratic 20x^2
-#define SEE_PRUNE_CAPTURE_CUTOFF 70
-#define SEE_PRUNE_CUTOFF 20
+#define SEE_PRUNE_CAPTURE_CUTOFF 92
+#define SEE_PRUNE_CUTOFF 18
 
 // delta pruning in QS
 #define DELTA_CUTOFF 150


### PR DESCRIPTION
Bench: 10206189

ELO   | 6.70 +- 4.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8920 W: 1955 L: 1783 D: 5182

Tuned SEE Cutoff values with Chess Tuning Tools. 50 iterations in the values were no longer changing so I stopped the test.