### PR TITLE
Simplify Aspiration Window

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -127,7 +127,7 @@ void* Search(void* arg) {
       // delta is our window for search. early depths get full searches
       // as we don't know what score to expect. Otherwise we start with a window of 16 (8x2), but
       // vary this slightly based on the previous depths window expansion count
-      int delta = depth >= 5 && abs(score) <= 1000 ? WINDOW + expands : CHECKMATE;
+      int delta = depth >= 5 && abs(score) <= 1000 ? WINDOW : CHECKMATE;
 
       expands = 0;
       alpha = max(score - delta, -CHECKMATE);


### PR DESCRIPTION
Bench: 9015328

ELO   | 2.86 +- 4.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 11680 W: 2453 L: 2357 D: 6870

This was originally tested a window of size 10, and did report a minor gain. However, it was most likely due to the window being able to go to size 8, rather than just variable adjustments. That adjustment has been removed and Berserk shows no loss.