### PR TITLE
Shift to MVVLVA for ordering in QS

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -479,12 +479,10 @@ void GenerateTacticalMoves(MoveList* moveList, Board* board) {
   // for tactical moves just SEE is utilized for ordering
   for (int i = 0; i < moveList->count; i++) {
     Move move = moveList->moves[i];
+    int attacker = MovePiece(move);
+    int victim = MoveEP(move) ? PAWN_WHITE : MovePromo(move) ? QUEEN_WHITE : board->squares[MoveEnd(move)];
 
-    int see = SEE(board, move);
-    if (MoveEP(move))
-      see += STATIC_MATERIAL_VALUE[PAWN_TYPE];
-
-    moveList->scores[i] = see;
+    moveList->scores[i] = MVV_LVA[attacker][victim];
   }
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -570,14 +570,11 @@ int Quiesce(int alpha, int beta, ThreadData* thread, PV* pv) {
   InitTacticalMoves(&moves);
 
   while ((move = NextMove(&moves, board, data))) {
-    int moveScore = moves.scores[moves.idx - 1];
+    int see = SEE(board, move);
     // a delta prune look-a-like by Halogen
     // prune based on SEE scores rather than flat mat val
-    if (eval + moveScore + DELTA_CUTOFF < alpha)
-      break;
-
-    if (moveScore < 0)
-      break;
+    if (eval + see + DELTA_CUTOFF < alpha || see < 0)
+      continue;
 
     data->moves[data->ply++] = move;
     MakeMove(move, board);


### PR DESCRIPTION
Bench: 9742334

ELO   | -0.63 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 45068 W: 9167 L: 9249 D: 26652