### PR TITLE
Killers/Counters logic adusted

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -33,8 +33,7 @@ const char* SQ_TO_COORD[] = {
 
 Move ParseMove(char* moveStr, Board* board) {
   MoveList moveList = {0};
-  SearchData data = {0};
-  GenerateAllMoves(&moveList, board, &data);
+  GenerateAllMoves(&moveList, board);
 
   int start = (moveStr[0] - 'a') + (8 - (moveStr[1] - '0')) * 8;
   int end = (moveStr[2] - 'a') + (8 - (moveStr[3] - '0')) * 8;

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -32,12 +32,12 @@ extern const int KILLER2_SCORE;
 extern const int COUNTER_SCORE;
 
 void AppendMove(MoveList* moveList, Move move);
-void GenerateAllMoves(MoveList* moveList, Board* board, SearchData* data);
+void GenerateAllMoves(MoveList* moveList, Board* board);
 void GenerateTacticalMoves(MoveList* moveList, Board* board);
 
-void InitAllMoves(MoveList* moves, Move hashMove);
-void InitTacticalMoves(MoveList* moves);
-Move NextMove(MoveList* moves, Board* board, SearchData* data);
+void InitAllMoves(MoveList* moves, SearchData* data, Move hashMove);
+void InitTacticalMoves(MoveList* moves, SearchData* data);
+Move NextMove(MoveList* moves, Board* board);
 uint8_t TopMoveIdx(MoveList* moves);
 void Swap(MoveList* moves, uint8_t a, uint8_t b);
 

--- a/src/perft.c
+++ b/src/perft.c
@@ -33,15 +33,15 @@ int Perft(int depth, Board* board) {
   MoveList moves;
 
   if (depth == 1) {
-    GenerateAllMoves(&moves, board, &PERFT_DUMMY_DATA);
+    GenerateAllMoves(&moves, board);
     return moves.count;
   }
 
-  InitAllMoves(&moves, NULL_MOVE);
+  InitAllMoves(&moves, &PERFT_DUMMY_DATA, NULL_MOVE);
 
   int nodes = 0;
 
-  while ((move = NextMove(&moves, board, &PERFT_DUMMY_DATA))) {
+  while ((move = NextMove(&moves, board))) {
     MakeMove(move, board);
     nodes += Perft(depth - 1, board);
     UndoMove(move, board);
@@ -59,9 +59,9 @@ void PerftTest(int depth, Board* board) {
 
   Move move;
   MoveList moves;
-  InitAllMoves(&moves, NULL_MOVE);
+  InitAllMoves(&moves, &PERFT_DUMMY_DATA, NULL_MOVE);
 
-  while ((move = NextMove(&moves, board, &PERFT_DUMMY_DATA))) {
+  while ((move = NextMove(&moves, board))) {
     MakeMove(move, board);
     int nodes = Perft(depth - 1, board);
     UndoMove(move, board);

--- a/src/types.h
+++ b/src/types.h
@@ -44,26 +44,7 @@ typedef uint64_t BitBoard;
 
 typedef uint32_t Move;
 
-// Move generation storage
-// moves/scores idx's match
-enum {
-  ALL_MOVES,
-  TACTICAL_MOVES
-};
 
-enum {
-  HASH_MOVE,
-  GEN_MOVES,
-  PLAY_MOVES,
-  NO_MORE_MOVES
-};
-
-typedef struct {
-  uint8_t type, phase, idx, count;
-  Move hashMove;
-  Move moves[MAX_MOVES];
-  int scores[MAX_MOVES];
-} MoveList;
 
 typedef struct {
   BitBoard pieces[12];     // individual piece data
@@ -246,6 +227,28 @@ typedef struct {
   SearchParams* params;
   ThreadData* threads;
 } SearchArgs;
+
+// Move generation storage
+// moves/scores idx's match
+enum {
+  ALL_MOVES,
+  TACTICAL_MOVES
+};
+
+enum {
+  HASH_MOVE,
+  GEN_MOVES,
+  PLAY_MOVES,
+  NO_MORE_MOVES
+};
+
+typedef struct {
+  SearchData* data;
+  Move hashMove, k1, k2, cm;
+  uint8_t type, phase, idx, count;
+  Move moves[MAX_MOVES];
+  int scores[MAX_MOVES];
+} MoveList;
 
 enum { WHITE, BLACK, BOTH };
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -218,14 +218,6 @@ void UCILoop() {
       Score s = Evaluate(&board, &threads[0]);
       printf("Score: %dcp\n", s);
     } else if (!strncmp(in, "moves", 5)) {
-      // Print possible moves. If a search has been run and stopped, it will
-      // print the moves in the order in which they would be searched on the
-      // next iteration. This has been very helpful to debug move ordering
-      // related problems.
-
-      MoveList moveList;
-      GenerateAllMoves(&moveList, &board, &threads->data);
-      PrintMoves(&moveList);
     } else if (!strncmp(in, "setoption name Hash value ", 26)) {
       int mb = GetOptionIntValue(in);
       mb = max(4, min(65536, mb));


### PR DESCRIPTION
Bench: 8955438

ELO   | 8.78 +- 6.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 4352 W: 981 L: 871 D: 2500

This is prep for fully-phased move generation. It seems to have gained a minor amount of Elo as there was a small speedup and the logic did adjust how the killers/counters can no longer change when looping through the moves.