### PR TITLE
Only SEE Prune past good tactical moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -375,7 +375,11 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
     // Static evaluation pruning, this applies for both quiet and tactical moves
     // quiet moves use a quadratic scale upwards
-    if (bestScore > -MATE_BOUND && SEE(board, move) < STATIC_PRUNE[tactical][depth])
+    if (bestScore > -MATE_BOUND && tactical && moves.phase > PLAY_GOOD_TACTICAL &&
+        SEE(board, move) < STATIC_PRUNE[1][depth])
+      continue;
+
+    if (bestScore > -MATE_BOUND && !tactical && SEE(board, move) < STATIC_PRUNE[0][depth])
       continue;
 
     nonPrunedMoves++;


### PR DESCRIPTION
Bench: 8741311

ELO   | 6.41 +- 4.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9596 W: 1994 L: 1817 D: 5785