### PR TITLE
More aggressive lmp

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -361,14 +361,14 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     if (skipMove == move)
       continue;
 
+    totalMoves++;
+
     int tactical = !!Tactical(move);
     int specialQuiet = !tactical && (move == moves.killer1 || move == moves.killer2 || move == moves.counter);
     int hist = !tactical ? data->hh[board->side][MoveStartEnd(move)] : 0;
 
     if (bestScore > -MATE_BOUND && depth <= 8 && totalMoves >= LMP[improving][depth])
       skipQuiets = 1;
-
-    totalMoves++;
 
     if (bestScore > -MATE_BOUND && !tactical && depth <= 2 && !specialQuiet && hist <= -2048 * depth * depth)
       continue;


### PR DESCRIPTION
Bench: 8015291

ELO   | 5.19 +- 4.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 10848 W: 2289 L: 2127 D: 6432