### PR TITLE
SEE Improvements

### DIFF
--- a/src/movepick.c
+++ b/src/movepick.c
@@ -166,11 +166,11 @@ Move NextMove(MoveList* moves, Board* board, int skipQuiets) {
         return NextMove(moves, board, skipQuiets);
       }
 
-      int see = 0;
-      if (MoveCapture(m) && !MoveEP(m) && PIECE_TYPE[board->squares[MoveEnd(m)]] < PIECE_TYPE[MovePiece(m)])
-        see = SEE(board, m);
+      int attacker = PIECE_TYPE[MovePiece(m)];
+      int victim = MoveEP(m) ? PAWN_TYPE : MoveCapture(m) ? PIECE_TYPE[board->squares[MoveEnd(m)]] : -1;
 
-      if (see < 0) {
+      int see;
+      if (attacker > victim && (see = SEE(board, m)) < 0) {
         moves->sTactical[idx] = see;
         ShiftToBadCaptures(moves, idx);
         return NextMove(moves, board, skipQuiets);

--- a/src/see.c
+++ b/src/see.c
@@ -26,6 +26,9 @@
 
 // Static exchange evaluation using The Swap Algorithm - https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm
 inline int SEE(Board* board, Move move) {
+  if (MoveCastle(move) || (!MoveCapture(move) && PIECE_TYPE[MovePiece(move)] == KING_TYPE))
+    return 0;
+
   BitBoard occupied = board->occupancies[BOTH];
   int side = board->side;
 
@@ -36,14 +39,17 @@ inline int SEE(Board* board, Move move) {
   int end = MoveEnd(move);
 
   BitBoard attackers = AttacksToSquare(board, end, board->occupancies[BOTH]);
-  int attackedPieceVal = STATIC_MATERIAL_VALUE[PIECE_TYPE[board->squares[MoveEnd(move)]]];
+  int attackedPieceVal = MoveEP(move) ? STATIC_MATERIAL_VALUE[PAWN_TYPE]
+                                      : STATIC_MATERIAL_VALUE[PIECE_TYPE[board->squares[MoveEnd(move)]]];
+  popBit(occupied, start);
+  if (MoveEP(move))
+    popBit(occupied, end - PAWN_DIRECTIONS[side]);
 
   side ^= 1;
   gain[0] = attackedPieceVal;
 
   int piece = MovePiece(move);
   attackedPieceVal = STATIC_MATERIAL_VALUE[PIECE_TYPE[piece]];
-  popBit(occupied, start);
 
   // Recalculate attacks if xray now open
   if (PIECE_TYPE[piece] == PAWN_TYPE || PIECE_TYPE[piece] == BISHOP_TYPE || PIECE_TYPE[piece] == QUEEN_TYPE)


### PR DESCRIPTION
ELO   | 0.42 +- 2.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 38492 W: 7701 L: 7654 D: 23137

Accepted as this passes [-4,1] bounds