### PR TITLE
Move SEE pruning for QSearch into the movepicker

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -20,7 +20,7 @@
 #include "types.h"
 
 void InitAllMoves(MoveList* moves, Move hashMove, SearchData* data);
-void InitTacticalMoves(MoveList* moves, SearchData* data);
+void InitTacticalMoves(MoveList* moves, SearchData* data, int cutoff);
 Move NextMove(MoveList* moves, Board* board, int skipQuiets);
 
 void PrintMoves(Board* board, ThreadData* thread);

--- a/src/search.c
+++ b/src/search.c
@@ -338,7 +338,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     if (depth > 4 && abs(beta) < MATE_BOUND &&
         !(ttHit && tt->depth >= depth - 3 && TTScore(tt, data->ply) < probBeta)) {
 
-      InitTacticalMoves(&moves, data);
+      InitTacticalMoves(&moves, data, 0);
       while ((move = NextMove(&moves, board, 1))) {
         data->moves[data->ply++] = move;
         MakeMove(move, board);
@@ -574,14 +574,11 @@ int Quiesce(int alpha, int beta, ThreadData* thread, PV* pv) {
 
   Move move;
   MoveList moves;
-  InitTacticalMoves(&moves, data);
+  InitTacticalMoves(&moves, data, alpha - eval - DELTA_CUTOFF);
 
   while ((move = NextMove(&moves, board, 1))) {
-    int see = SEE(board, move);
-    // a delta prune look-a-like by Halogen
-    // prune based on SEE scores rather than flat mat val
-    if (eval + see + DELTA_CUTOFF < alpha || see < 0)
-      continue;
+    if (moves.phase > PLAY_GOOD_TACTICAL)
+      break;
 
     data->moves[data->ply++] = move;
     MakeMove(move, board);

--- a/src/types.h
+++ b/src/types.h
@@ -249,6 +249,7 @@ enum {
 typedef struct {
   SearchData* data;
   Move hashMove, killer1, killer2, counter;
+  int seeCutoff;
   uint8_t type, phase, nTactical, nQuiets, nBadTactical;
 
   Move tactical[MAX_MOVES];


### PR DESCRIPTION
Bench: 7875737

ELO   | 5.29 +- 3.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12224 W: 2537 L: 2351 D: 7336