### PR TITLE
Store eval immediately

### DIFF
--- a/src/endgame.c
+++ b/src/endgame.c
@@ -21,6 +21,7 @@
 #include "board.h"
 #include "endgame.h"
 #include "eval.h"
+#include "search.h"
 #include "util.h"
 
 const uint8_t kpkResults[2 * 64 * 64 * 24 / 8] = {

--- a/src/eval.c
+++ b/src/eval.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "attacks.h"
 #include "bits.h"
@@ -26,7 +27,7 @@
 #include "move.h"
 #include "movegen.h"
 #include "pawns.h"
-#include "string.h"
+#include "search.h"
 #include "tune.h"
 #include "types.h"
 #include "util.h"

--- a/src/eval.h
+++ b/src/eval.h
@@ -28,7 +28,6 @@
 #define rel(sq, side) ((side) ? MIRROR[(sq)] : (sq))
 #define distance(a, b) max(abs(rank(a) - rank(b)), abs(file(a) - file(b)))
 
-#define UNKNOWN INT32_MAX
 extern EvalCoeffs C;
 
 extern const int MAX_SCALE;

--- a/src/search.h
+++ b/src/search.h
@@ -20,7 +20,8 @@
 #include "types.h"
 
 // search specific score evals
-#define CHECKMATE INT16_MAX
+#define UNKNOWN 32257 // this must be higher than CHECKMATE (some conditional logic relies on this)
+#define CHECKMATE 32256
 #define MATE_BOUND 30000
 #define TB_WIN_BOUND 20000
 

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -60,6 +60,9 @@ inline void TTClear() { memset(TT.buckets, 0, (TT.mask + 1ULL) * sizeof(TTBucket
 inline void TTUpdate() { TT.age += 1; }
 
 inline int TTScore(TTEntry* e, int ply) {
+  if (e->score == UNKNOWN)
+    return UNKNOWN;
+
   return e->score > MATE_BOUND ? e->score - ply : e->score < -MATE_BOUND ? e->score + ply : e->score;
 }
 
@@ -81,7 +84,7 @@ inline TTEntry* TTProbe(int* hit, uint64_t hash) {
   return 0;
 }
 
-inline void TTPut(uint64_t hash, uint8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval) {
+inline void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval) {
 #ifdef TUNE
   return;
 #else

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -26,7 +26,8 @@
 typedef struct {
   uint32_t hash, move;
   int16_t eval, score;
-  uint8_t flags, depth, age;
+  int8_t depth;
+  uint8_t flags, age;
 } TTEntry;
 
 typedef struct {
@@ -40,7 +41,7 @@ typedef struct {
   uint8_t age;
 } TTTable;
 
-enum { TT_LOWER = 1, TT_UPPER = 2, TT_EXACT = 4 };
+enum { TT_UNKNOWN = 0, TT_LOWER = 1, TT_UPPER = 2, TT_EXACT = 4 };
 
 extern TTTable TT;
 
@@ -51,7 +52,7 @@ void TTUpdate();
 void TTPrefetch(uint64_t hash);
 TTEntry* TTProbe(int* hit, uint64_t hash);
 int TTScore(TTEntry* e, int ply);
-void TTPut(uint64_t hash, uint8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval);
+void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval);
 int TTFull();
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -18,14 +18,14 @@
 #define TYPES_H
 
 #include <setjmp.h>
-#include <stdint.h>
+#include <inttypes.h>
 
 #ifdef TUNE
 #define MAX_SEARCH_PLY 16
 #define MAX_MOVES 256
 #define MAX_GAME_PLY 32
 #else
-#define MAX_SEARCH_PLY 128
+#define MAX_SEARCH_PLY INT8_MAX
 #define MAX_MOVES 256
 #define MAX_GAME_PLY 1024
 #endif


### PR DESCRIPTION
Bench: 8607108

ELO   | 5.81 +- 4.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10768 W: 2239 L: 2059 D: 6470

This required a bit of work to get "Unknown" scores recognized, but overall leads to a speedup because evaluated nodes that were pruned, would not get their eval stored in the TT.