### PR TITLE
Allow QSearch Replacements

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -105,7 +105,7 @@ inline void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move
     }
 
     if (entry->hash == shortHash) {
-      if (entry->depth >= depth * 2 && !(flag & TT_EXACT))
+      if (entry->depth > depth * 2 && !(flag & TT_EXACT))
         return;
 
       toReplace = entry;


### PR DESCRIPTION
Bench: 8453130

ELO   | 0.16 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 31352 W: 6112 L: 6098 D: 19142

Passes bounds of [-5,0]