### PR TITLE
Don't sort bad captures

### DIFF
--- a/src/movepick.c
+++ b/src/movepick.c
@@ -107,12 +107,12 @@ inline Move PopQuiet(MoveList* moves, int idx) {
   return temp;
 }
 
-inline Move PopBadCapture(MoveList* moves, int idx) {
-  Move temp = moves->tactical[idx];
+inline Move PopBadCapture(MoveList* moves) {
+  Move temp = moves->tactical[MAX_MOVES - 1];
 
   moves->nBadTactical--;
-  moves->tactical[idx] = moves->tactical[MAX_MOVES - 1 - moves->nBadTactical];
-  moves->sTactical[idx] = moves->tactical[MAX_MOVES - 1 - moves->nBadTactical];
+  moves->tactical[MAX_MOVES - 1] = moves->tactical[MAX_MOVES - 1 - moves->nBadTactical];
+  moves->sTactical[MAX_MOVES - 1] = moves->tactical[MAX_MOVES - 1 - moves->nBadTactical];
 
   return temp;
 }
@@ -236,8 +236,7 @@ Move NextMove(MoveList* moves, Board* board, int skipQuiets) {
     // fallthrough
   case PLAY_BAD_TACTICAL:
     if (moves->nBadTactical > 0) {
-      int idx = GetTopReverseIdx(moves->sTactical, moves->nBadTactical);
-      Move m = PopBadCapture(moves, idx);
+      Move m = PopBadCapture(moves);
 
       return m != moves->hashMove ? m : NextMove(moves, board, skipQuiets);
     }


### PR DESCRIPTION
Bench: 7041404

ELO   | 3.82 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 14936 W: 2811 L: 2647 D: 9478

In an effort to save time, don't sort bad captures because they're all bad anyways.