### PR TITLE
Under Promotion Sorting and SE Tweak

### DIFF
--- a/src/movepick.c
+++ b/src/movepick.c
@@ -121,9 +121,10 @@ void ScoreTacticalMoves(MoveList* moves, Board* board) {
   for (int i = 0; i < moves->nTactical; i++) {
     Move m = moves->tactical[i];
     int attacker = MovePiece(m);
-    int victim = MoveEP(m) ? PAWN_WHITE : MovePromo(m) ? MovePromo(m) : board->squares[MoveEnd(m)];
-
-    moves->sTactical[i] = MVV_LVA[attacker][victim];
+    moves->sTactical[i] = MoveEP(m)                   ? MVV_LVA[attacker][PAWN_WHITE]
+                          : !MovePromo(m)             ? MVV_LVA[attacker][board->squares[MoveEnd(m)]]
+                          : MovePromo(m) > ROOK_BLACK ? MVV_LVA[attacker][QUEEN_WHITE]
+                                                      : -1;
   }
 }
 
@@ -132,17 +133,6 @@ void ScoreQuietMoves(MoveList* moves, Board* board, SearchData* data) {
     Move m = moves->quiet[i];
 
     moves->sQuiet[i] = data->hh[board->side][MoveStartEnd(m)];
-  }
-}
-
-void ScoreTacticalMovesWithSEE(MoveList* moves, Board* board) {
-  for (int i = 0; i < moves->nTactical; i++) {
-    Move m = moves->tactical[i];
-    int see = SEE(board, m);
-    if (MoveEP(m))
-      see += STATIC_MATERIAL_VALUE[PAWN_TYPE];
-
-    moves->sTactical[i] = see;
   }
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -407,7 +407,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     int extension = 0;
     if (depth >= 8 && !skipMove && !isRoot && ttHit && move == tt->move && tt->depth >= depth - 3 &&
         abs(ttScore) < MATE_BOUND && (tt->flags & TT_LOWER)) {
-      int sBeta = max(ttScore - depth * 2, -CHECKMATE);
+      int sBeta = max(ttScore - 3 * depth / 2, -CHECKMATE);
       int sDepth = depth / 2 - 1;
 
       data->skipMove[data->ply] = move;


### PR DESCRIPTION
Bench: 7399901

ELO   | 3.20 +- 3.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 19216 W: 3703 L: 3526 D: 11987

There were originally tested separately, and both presented as tiny Elo gains. Together they do better.