### PR TITLE
Fix Prob Cut (applying hash move during SE)

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -340,9 +340,11 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     // less than beta + margin, then we run a shallow search to look
     int probBeta = beta + 100;
     if (depth > 4 && abs(beta) < MATE_BOUND && !(ttHit && tt->depth >= depth - 3 && ttScore < probBeta)) {
-
       InitTacticalMoves(&moves, data, 0);
       while ((move = NextMove(&moves, board, 1))) {
+        if (skipMove == move)
+          continue;
+
         data->moves[data->ply++] = move;
         MakeMove(move, board);
 


### PR DESCRIPTION
Bench: 7352056

ELO   | -0.04 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 49352 W: 9596 L: 9602 D: 30154