### PR TITLE
Lower restriction on double extend

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -417,7 +417,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
       // no score failed above sBeta, so this is singular
       if (score < sBeta)
-        extension = 1 + (!isPV && score < sBeta - 100);
+        extension = 1 + (!isPV && score < sBeta - 50);
     }
 
     // re-capture extension - looks for a follow up capture on the same square


### PR DESCRIPTION
Bench: 7509017

ELO   | 1.21 +- 1.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 164032 W: 31950 L: 31381 D: 100701