### PR TITLE
Simplify out KingArea square attacks

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -316,10 +316,8 @@ const Score BLOCKED_PAWN_STORM[8] = {
 };
 
 const Score KS_ATTACKER_WEIGHTS[5] = {
- 0, 32, 31, 18, 24
+ 0, 33, 32, 19, 25
 };
-
-const Score KS_ATTACK = 4;
 
 const Score KS_WEAK_SQS = 78;
 
@@ -551,13 +549,11 @@ Score PieceEval(Board* board, EvalData* data, int side) {
 
       if (movement & enemyKingArea) {
         data->ksAttackWeight[side] += KS_ATTACKER_WEIGHTS[pieceType];
-        data->ksSqAttackCount[side] += bits(movement & enemyKingArea);
         data->ksAttackerCount[side]++;
 
         if (T) {
           C.ksAttackerCount[xside]++;
           C.ksAttackerWeights[xside][pieceType]++;
-          C.ksAttack[xside] += bits(movement & enemyKingArea);
         }
       }
 
@@ -824,7 +820,6 @@ Score KingSafety(Board* board, EvalData* data, int side) {
                  + (KS_QUEEN_CHECK * bits(possibleQueenChecks & vulnerable))    //
                  + (KS_UNSAFE_CHECK * unsafeChecks)                             //
                  + (KS_WEAK_SQS * bits(weak & kingArea))                        // weak sqs makes you vulnerable
-                 + (KS_ATTACK * data->ksSqAttackCount[xside])                   // general pieces aimed
                  + (KS_PINNED * bits(board->pinned & board->occupancies[side])) //
                  + (KS_ENEMY_QUEEN * !board->pieces[QUEEN[xside]])              //
                  + (KS_KNIGHT_DEFENSE * !!(data->attacks[side][KNIGHT_TYPE] & kingArea)); // knight f8 = no m8

--- a/src/eval.h
+++ b/src/eval.h
@@ -98,7 +98,6 @@ extern const Score BLOCKED_PAWN_STORM[8];
 extern const Score KS_KING_FILE[4];
 
 extern const Score KS_ATTACKER_WEIGHTS[5];
-extern const Score KS_ATTACK;
 extern const Score KS_PINNED;
 extern const Score KS_WEAK_SQS;
 extern const Score KS_KNIGHT_CHECK;

--- a/src/tune.c
+++ b/src/tune.c
@@ -227,7 +227,6 @@ void UpdateWeights(Weights* weights) {
     for (int i = 0; i < 5; i++)
       UpdateParam(&weights->ksAttackerWeight[i].mg);
 
-    UpdateParam(&weights->ksAttack.mg);
     UpdateParam(&weights->ksWeakSqs.mg);
     UpdateParam(&weights->ksPinned.mg);
     UpdateParam(&weights->ksKnightCheck.mg);
@@ -438,7 +437,6 @@ double UpdateAndTrain(int epoch, int n, Position* positions, Weights* weights) {
     for (int i = 0; i < 5; i++)
       weights->ksAttackerWeight[i].mg.g += w->ksAttackerWeight[i].mg.g;
 
-    weights->ksAttack.mg.g += w->ksAttack.mg.g;
     weights->ksWeakSqs.mg.g += w->ksWeakSqs.mg.g;
     weights->ksPinned.mg.g += w->ksPinned.mg.g;
     weights->ksKnightCheck.mg.g += w->ksKnightCheck.mg.g;
@@ -723,11 +721,6 @@ void UpdateKingSafetyGradients(Position* position, double loss, Weights* weights
                                          position->coeffs.ksAttackerCount[WHITE];
   }
 
-  weights->ksAttack.mg.g += (mgBase / 512) * fmax(ks->bDanger, 0) * position->coeffs.ksAttack[BLACK];
-  weights->ksAttack.mg.g += (egBase / 32) * (ks->bDanger > 0) * position->coeffs.ksAttack[BLACK];
-  weights->ksAttack.mg.g -= (mgBase / 512) * fmax(ks->wDanger, 0) * position->coeffs.ksAttack[WHITE];
-  weights->ksAttack.mg.g -= (egBase / 32) * (ks->wDanger > 0) * position->coeffs.ksAttack[WHITE];
-
   weights->ksWeakSqs.mg.g += (mgBase / 512) * fmax(ks->bDanger, 0) * position->coeffs.ksWeakSqs[BLACK];
   weights->ksWeakSqs.mg.g += (egBase / 32) * (ks->bDanger > 0) * position->coeffs.ksWeakSqs[BLACK];
   weights->ksWeakSqs.mg.g -= (mgBase / 512) * fmax(ks->wDanger, 0) * position->coeffs.ksWeakSqs[WHITE];
@@ -918,7 +911,6 @@ void EvaluateKingSafetyValues(double* mg, double* eg, Position* position, Weight
                weights->ksAttackerWeight[i].mg.value;
   }
 
-  wDanger += position->coeffs.ksAttack[WHITE] * weights->ksAttack.mg.value;
   wDanger += position->coeffs.ksWeakSqs[WHITE] * weights->ksWeakSqs.mg.value;
   wDanger += position->coeffs.ksPinned[WHITE] * weights->ksPinned.mg.value;
   wDanger += position->coeffs.ksKnightCheck[WHITE] * weights->ksKnightCheck.mg.value;
@@ -929,7 +921,6 @@ void EvaluateKingSafetyValues(double* mg, double* eg, Position* position, Weight
   wDanger += position->coeffs.ksEnemyQueen[WHITE] * weights->ksEnemyQueen.mg.value;
   wDanger += position->coeffs.ksKnightDefense[WHITE] * weights->ksKnightDefense.mg.value;
 
-  bDanger += position->coeffs.ksAttack[BLACK] * weights->ksAttack.mg.value;
   bDanger += position->coeffs.ksWeakSqs[BLACK] * weights->ksWeakSqs.mg.value;
   bDanger += position->coeffs.ksPinned[BLACK] * weights->ksPinned.mg.value;
   bDanger += position->coeffs.ksKnightCheck[BLACK] * weights->ksKnightCheck.mg.value;
@@ -1232,7 +1223,6 @@ void InitKingSafetyWeights(Weights* weights) {
   for (int i = 1; i < 5; i++)
     weights->ksAttackerWeight[i].mg.value = KS_ATTACKER_WEIGHTS[i];
 
-  weights->ksAttack.mg.value = KS_ATTACK;
   weights->ksWeakSqs.mg.value = KS_WEAK_SQS;
   weights->ksPinned.mg.value = KS_PINNED;
   weights->ksKnightCheck.mg.value = KS_KNIGHT_CHECK;
@@ -1464,8 +1454,6 @@ void PrintWeights(Weights* weights, int epoch, double error) {
           (int)round(weights->ksAttackerWeight[2].mg.value), (int)round(weights->ksAttackerWeight[3].mg.value),
           (int)round(weights->ksAttackerWeight[4].mg.value));
   fprintf(fp, "\n};\n");
-
-  fprintf(fp, "\nconst Score KS_ATTACK = %d;\n", (int)round(weights->ksAttack.mg.value));
 
   fprintf(fp, "\nconst Score KS_WEAK_SQS = %d;\n", (int)round(weights->ksWeakSqs.mg.value));
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -78,7 +78,6 @@ typedef struct {
   Weight blockedPawnStorm[8];
 
   Weight ksAttackerWeight[5];
-  Weight ksAttack;
   Weight ksWeakSqs;
   Weight ksPinned;
   Weight ksKnightCheck;

--- a/src/types.h
+++ b/src/types.h
@@ -164,7 +164,6 @@ typedef struct {
   int danger[2];
   int8_t ksAttackerCount[2];
   int8_t ksAttackerWeights[2][5];
-  int8_t ksAttack[2];
   int8_t ksWeakSqs[2];
   int8_t ksPinned[2];
   int8_t ksKnightCheck[2];
@@ -199,7 +198,6 @@ typedef struct {
   BitBoard allAttacks[2];  // all attacks
   BitBoard twoAttacks[2];  // squares attacked twice
   Score ksAttackWeight[2]; // king safety attackers weight
-  int ksSqAttackCount[2];  // king safety sq attack count
   int ksAttackerCount[2];  // attackers
 
   BitBoard passedPawns;


### PR DESCRIPTION
Bench: 7109541

ELO   | 0.96 +- 2.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 23592 W: 4532 L: 4467 D: 14593

This value tuned very low, and was able to be simplified out.
