### PR TITLE
Reuse evaluation when within Singular Extension

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -290,7 +290,14 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     depth--;
 
   // pull previous static eval from tt - this is depth independent
-  int eval = data->evals[data->ply] = board->checkers ? UNKNOWN : (ttHit ? tt->eval : Evaluate(board, thread));
+  int eval;
+  if (!skipMove) {
+    eval = data->evals[data->ply] = board->checkers ? UNKNOWN : (ttHit ? tt->eval : Evaluate(board, thread));
+  } else {
+    // after se, just used already determined eval
+    eval = data->evals[data->ply];
+  }
+
   if (!ttHit)
     TTPut(board->zobrist, INT8_MIN, UNKNOWN, TT_UNKNOWN, NULL_MOVE, data->ply, eval);
 


### PR DESCRIPTION
Bench: 10424488

ELO   | 1.22 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.43 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 21128 W: 3995 L: 3921 D: 13212

Most likely a very minor speedup that isn't able to prove much Elo.