### PR TITLE
Counter move history pruning

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -87,3 +87,12 @@ int GetHistory(SearchData* data, Move move, int stm) {
 
   return history;
 }
+
+int GetCounterHistory(SearchData* data, Move move) {
+  if (Tactical(move))
+    return 0; // TODO: Capture history
+
+  Move parent = data->ply > 0 ? data->moves[data->ply - 1] : NULL_MOVE;
+  return parent ? data->ch[PIECE_TYPE[MovePiece(parent)]][MoveEnd(parent)][PIECE_TYPE[MovePiece(move)]][MoveEnd(move)]
+                : 0;
+}

--- a/src/history.h
+++ b/src/history.h
@@ -24,5 +24,6 @@ void AddCounterMove(SearchData* data, Move move, Move parent);
 void AddHistoryHeuristic(int* entry, int inc);
 void UpdateHistories(SearchData* data, Move bestMove, int depth, int stm, Move quiets[], int nQ);
 int GetHistory(SearchData* data, Move move, int stm);
+int GetCounterHistory(SearchData* data, Move move);
 
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -386,9 +386,15 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     int tactical = !!Tactical(move);
     int specialQuiet = !tactical && (move == moves.killer1 || move == moves.killer2 || move == moves.counter);
     int hist = !tactical ? GetHistory(data, move, board->side) : 0;
+    int counterHist = !tactical ? GetCounterHistory(data, move) : 0;
 
     if (bestScore > -MATE_BOUND && depth <= 8 && totalMoves >= LMP[improving][depth])
       skipQuiets = 1;
+
+    // counter move history pruning
+    if (bestScore > -MATE_BOUND && !Tactical(move) && !specialQuiet && depth <= 2 &&
+        counterHist <= -1024 * depth * (depth + improving))
+      continue;
 
     // Static evaluation pruning, this applies for both quiet and tactical moves
     // quiet moves use a quadratic scale upwards

--- a/src/search.c
+++ b/src/search.c
@@ -392,7 +392,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
       skipQuiets = 1;
 
     // counter move history pruning
-    if (bestScore > -MATE_BOUND && !tactical && !specialQuiet && depth <= 2 && counterHist <= -4096 * depth)
+    if (bestScore > -MATE_BOUND && !tactical && !specialQuiet && depth <= 2 && counterHist <= -8192)
       continue;
 
     // Static evaluation pruning, this applies for both quiet and tactical moves

--- a/src/search.c
+++ b/src/search.c
@@ -392,8 +392,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
       skipQuiets = 1;
 
     // counter move history pruning
-    if (bestScore > -MATE_BOUND && !Tactical(move) && !specialQuiet && depth <= 2 &&
-        counterHist <= -1024 * depth * (depth + improving))
+    if (bestScore > -MATE_BOUND && !tactical && !specialQuiet && depth <= 2 && counterHist <= -4096 * depth)
       continue;
 
     // Static evaluation pruning, this applies for both quiet and tactical moves


### PR DESCRIPTION
Bench: 8413467

ELO   | 4.95 +- 3.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 10800 W: 2087 L: 1933 D: 6780

Similar to the original history pruning, but specific to the counter history score.