### PR TITLE
Don't apply extensions to moves that meet SE criteria, but fail

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -434,16 +434,16 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
     // history extension - if the tt move has a really good history score, extend.
     // thank you to Connor, author of Seer for this idea
-    if (!extension && !isRoot && depth >= 8 && ttHit && move == tt->move && hist >= 98304)
+    else if (!isRoot && depth >= 8 && ttHit && move == tt->move && hist >= 98304)
       extension = 1;
 
     // castle extensions
-    if (!extension && MoveCastle(move))
+    else if (MoveCastle(move))
       extension = 1;
 
     // re-capture extension - looks for a follow up capture on the same square
     // as the previous capture
-    if (!extension && isPV && !isRoot) {
+    else if (isPV && !isRoot) {
       Move parentMove = data->moves[data->ply - 1];
 
       if (!(MoveCapture(parentMove) ^ MoveCapture(move)) && MoveEnd(parentMove) == MoveEnd(move))


### PR DESCRIPTION
Bench: 9648990

ELO   | 8.13 +- 5.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 6112 W: 1204 L: 1061 D: 3847

This is not true for moves that give check. Those are still always extended. The logic behind this is, if there are multiple good moves in a position (after SE has failed), we shouldn't extend the move irregardless, rather just wait for the next depth iteration.

