### PR TITLE
Less aggressive lazy eval

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -947,7 +947,7 @@ Score Evaluate(Board* board, ThreadData* thread) {
 
   s += Imbalance(board, WHITE) - Imbalance(board, BLACK);
 
-  if (T || abs(scoreMG(s) + scoreEG(s)) / 2 < 640) {
+  if (T || abs(scoreMG(s) + scoreEG(s)) / 2 < 1024) {
     s += PieceEval(board, &data, WHITE) - PieceEval(board, &data, BLACK);
     s += PasserEval(board, &data, WHITE) - PasserEval(board, &data, BLACK);
     s += Threats(board, &data, WHITE) - Threats(board, &data, BLACK);


### PR DESCRIPTION
Bench: 9746231

ELO   | 1.78 +- 3.00 (95%)
SPRT  | 32.0+0.32s Threads=1 Hash=64MB
LLR   | 1.08 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 14016 W: 1950 L: 1878 D: 10188

This passed [-5,0] bounds and is being merged as it makes me sleep better at night.