### PR TITLE
Remove depth limit on LMP

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -389,7 +389,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     int counterHist = !tactical ? GetCounterHistory(data, move) : 0;
 
     if (bestScore > -MATE_BOUND) {
-      if (depth <= 8 && totalMoves >= LMP[improving][depth])
+      if (totalMoves >= LMP[improving][depth])
         skipQuiets = 1;
 
       if (!tactical && !specialQuiet && depth < 3 && counterHist <= -8192)


### PR DESCRIPTION
Bench: 9843565

ELO   | 3.00 +- 3.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 11224 W: 2073 L: 1976 D: 7175