### PR TITLE
Allow higher LMR for special quiet moves (killers/counters)

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -463,7 +463,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
       R = LMR[min(depth, 63)][min(nonPrunedMoves, 63)];
 
       if (specialQuiet) {
-        R = min(2, R);
+        R = min(3, R);
       } else if (!tactical) {
         // increase reduction on non-pv
         if (!isPV)


### PR DESCRIPTION
Bench: 8081693

ELO   | 3.75 +- 3.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 15648 W: 3097 L: 2928 D: 9623