### PR TITLE
Zero minimum for QSearch Futility Threshold

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -608,7 +608,9 @@ int Quiesce(int alpha, int beta, ThreadData* thread, PV* pv) {
 
   Move move;
   MoveList moves;
-  InitTacticalMoves(&moves, data, alpha - eval - DELTA_CUTOFF);
+
+  int seeThreshold = max(0, alpha - eval - DELTA_CUTOFF);
+  InitTacticalMoves(&moves, data, seeThreshold);
 
   while ((move = NextMove(&moves, board, 1))) {
     if (moves.phase > PLAY_GOOD_TACTICAL)


### PR DESCRIPTION
Bench: 7763390

ELO   | 11.64 +- 6.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 4120 W: 853 L: 715 D: 2552