### PR TITLE
Probcut margin 110

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -350,7 +350,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     // Prob cut
     // If a relatively deep search from our TT doesn't say this node is
     // less than beta + margin, then we run a shallow search to look
-    int probBeta = beta + 100;
+    int probBeta = beta + 110;
     if (depth > 4 && abs(beta) < MATE_BOUND && !(ttHit && tt->depth >= depth - 3 && ttScore < probBeta)) {
       InitTacticalMoves(&moves, data, 0);
       while ((move = NextMove(&moves, board, 1))) {


### PR DESCRIPTION
Bench: 6862435

ELO   | 2.77 +- 2.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 24344 W: 4766 L: 4572 D: 15006