### PR TITLE
Less reduction for captures on PV

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -477,6 +477,9 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
         R -= hist / 24576;
       } else {
         R--;
+
+        if (isPV)
+          R--;
       }
 
       // prevent dropping into QS, extending, or reducing all extensions


### PR DESCRIPTION
Bench: 8651119

ELO   | 2.47 +- 2.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 34696 W: 8609 L: 8362 D: 17725