### PR TITLE
Limit check extension to sub SE depths

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -464,7 +464,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     MakeMove(move, board);
 
     // apply extensions
-    int newDepth = depth + max(extension, !!board->checkers);
+    int newDepth = depth + max(extension, (board->checkers && depth < 8));
 
     // Late move reductions
     int R = 1;


### PR DESCRIPTION
Bench: 6490014

ELO   | 2.19 +- 2.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 44680 W: 11163 L: 10882 D: 22635