### PR TITLE
Adjust LMR for Special Quiet Moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -530,9 +530,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     if (depth > 2 && nonPrunedMoves > 1) {
       R = LMR[min(depth, 63)][min(nonPrunedMoves, 63)];
 
-      if (specialQuiet) {
-        R = min(3, R);
-      } else if (!tactical) {
+      if (!tactical) {
         // increase reduction on non-pv
         if (!isPV)
           R++;
@@ -540,6 +538,9 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
         // increase reduction if our eval is declining
         if (!improving)
           R++;
+
+        if (specialQuiet)
+          R -= 2;
 
         if (MoveCapture(nullThreat) && MoveStart(move) != MoveEnd(nullThreat) && !board->checkers)
           R++;


### PR DESCRIPTION
Bench: 6612352

ELO   | 6.31 +- 4.16 (95%)
SPRT  | 32.0+0.32s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 7600 W: 1150 L: 1012 D: 5438