### PR TITLE
Futility Pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -465,6 +465,9 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
       if (totalMoves >= LMP[improving][depth])
         skipQuiets = 1;
 
+      if (!tactical && !board->checkers && eval + 100 * depth <= alpha && depth <= 8 && hist < 50000 / (1 + improving))
+        skipQuiets = 1;
+
       if (!tactical && !specialQuiet && depth < 3 && counterHist <= -8192)
         continue;
 


### PR DESCRIPTION
Bench: 6526863

If a quiet move is way below alpha, then unless it's history is really high, prune it and the rest of the quiet moves (which are ordered on history).

ELO   | 3.55 +- 3.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 17312 W: 3602 L: 3425 D: 10285