### PR TITLE
TT Capture LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -556,6 +556,8 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
         if (MoveCapture(nullThreat) && MoveStart(move) != MoveEnd(nullThreat) && !board->checkers)
           R++;
 
+        R += !!MoveCapture(hashMove);
+
         // adjust reduction based on historical score
         R -= hist / 24576;
       } else {


### PR DESCRIPTION
Bench: 5206585

If the TT move was a capture, then increase the reduction of quiet moves.

ELO   | 2.32 +- 2.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 32968 W: 6693 L: 6473 D: 19802