### PR TITLE
Increase reduction for bad tactical moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -559,7 +559,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
         // adjust reduction based on historical score
         R -= hist / 24576;
       } else {
-        R--;
+        R -= (depth > 5 || moves.phase != PLAY_BAD_TACTICAL);
 
         if (isPV)
           R--;


### PR DESCRIPTION
Bench: 6020483

If we are below depth 5, increase the reduction for all bad tactical moves.

ELO   | 8.48 +- 5.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 5904 W: 1249 L: 1105 D: 3550