### PR TITLE
Skip quiets with bad history when below alpha

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -468,6 +468,9 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
       if (!tactical && !specialQuiet && depth < 3 && counterHist <= -8192)
         continue;
 
+      if (!tactical && !board->checkers && eval + 100 * depth <= alpha && depth <= 8 && hist < 50000 / (1 + improving))
+        skipQuiets = 1;
+
       if (tactical && moves.phase > PLAY_GOOD_TACTICAL && SEE(board, move) < STATIC_PRUNE[1][depth])
         continue;
 


### PR DESCRIPTION
Bench: 5931663

ELO   | 1.93 +- 2.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 46088 W: 9396 L: 9140 D: 27552

ELO   | 4.44 +- 3.50 (95%)
SPRT  | 32.0+0.32s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 11664 W: 1876 L: 1727 D: 8061