### PR TITLE
Scale down time spend when bestmove is stable

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -229,12 +229,12 @@ void* Search(void* arg) {
         continue;
 
       int diff = results->scores[depth] - results->scores[depth - 1];
-      
+
       // increment search stability if best move remains the same, otherwise reset
-      if (results->bestMoves[depth] == results->bestMoves[depth - 1]) 
-        searchStability = min(64, searchStability + 6); 
-      else 
-        searchStability = 0; 
+      if (results->bestMoves[depth] == results->bestMoves[depth - 1])
+        searchStability = min(64, searchStability + 6);
+      else
+        searchStability = 0;
 
       if (abs(diff) <= WINDOW)
         continue;
@@ -244,10 +244,10 @@ void* Search(void* arg) {
       else
         params->alloc *= fmin(1.04, 1.02 * (diff / WINDOW));
 
-      if (GetTimeMS() - params->start > (128 - searchStability) * min(params->alloc, params->max) / 128) { 
-        params->stopped = 1; 
-        break; 
-      } 
+      if (GetTimeMS() - params->start > (128 - searchStability) * params->alloc / 128) {
+        params->stopped = 1;
+        break;
+      }
     }
   }
 

--- a/src/search.c
+++ b/src/search.c
@@ -129,6 +129,7 @@ void* Search(void* arg) {
   SearchResults* results = thread->results;
   Board* board = &thread->board;
   int mainThread = !thread->idx;
+  int searchStability = 0;
 
   int alpha = -CHECKMATE;
   int beta = CHECKMATE;
@@ -228,6 +229,12 @@ void* Search(void* arg) {
         continue;
 
       int diff = results->scores[depth] - results->scores[depth - 1];
+      
+      // increment search stability if best move remains the same, otherwise reset
+      if (results->bestMoves[depth] == results->bestMoves[depth - 1]) 
+        searchStability = min(64, searchStability + 6); 
+      else 
+        searchStability = 0; 
 
       if (abs(diff) <= WINDOW)
         continue;
@@ -236,6 +243,11 @@ void* Search(void* arg) {
         params->alloc *= fmin(1.16, 1.04 * (-diff / WINDOW));
       else
         params->alloc *= fmin(1.04, 1.02 * (diff / WINDOW));
+
+      if (GetTimeMS() - params->start > (128 - searchStability) * min(params->alloc, params->max) / 128) { 
+        params->stopped = 1; 
+        break; 
+      } 
     }
   }
 


### PR DESCRIPTION
Bench: 5931663

ELO   | 3.01 +- 2.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 21912 W: 4462 L: 4272 D: 13178

ELO   | 3.87 +- 3.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 14008 W: 2319 L: 2163 D: 9526