### PR TITLE
Tactical History adjusted based on material values

### DIFF
--- a/src/movepick.c
+++ b/src/movepick.c
@@ -133,8 +133,8 @@ void ScoreTacticalMoves(MoveList* moves, Board* board) {
   for (int i = 0; i < moves->nTactical; i++) {
     Move m = moves->tactical[i];
 
-    moves->sTactical[i] =
-        GetTacticalHistory(moves->data, board, m) + STATIC_MATERIAL_VALUE[PIECE_TYPE[board->squares[MoveEnd(m)]]] * 16;
+    int captured = PIECE_TYPE[board->squares[MoveEnd(m)]];
+    moves->sTactical[i] = GetTacticalHistory(moves->data, board, m) + scoreMG(MATERIAL_VALUES[captured]) * 16;
   }
 }
 


### PR DESCRIPTION
Bench: 6026243

ELO   | 3.75 +- 3.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 16944 W: 3820 L: 3637 D: 9487

ELO   | -0.19 +- 1.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 43160 W: 6851 L: 6874 D: 29435