### PR TITLE
Reset history on `ucinewgame`

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -72,6 +72,9 @@ void ResetThreadPool(ThreadData* threads) {
     memset(&threads[i].data.killers, 0, sizeof(threads[i].data.killers));
     memset(&threads[i].data.counters, 0, sizeof(threads[i].data.counters));
     memset(&threads[i].data.hh, 0, sizeof(threads[i].data.hh));
+    memset(&threads[i].data.ch, 0, sizeof(threads[i].data.ch));
+    memset(&threads[i].data.fh, 0, sizeof(threads[i].data.fh));
+    memset(&threads[i].data.th, 0, sizeof(threads[i].data.th));
     memset(&threads[i].pawnHashTable, 0, PAWN_TABLE_SIZE * sizeof(PawnHashEntry));
     memset(&threads[i].board, 0, sizeof(Board));
   }


### PR DESCRIPTION
Bench: 6215927

This was an oversight, even though it loses elo, it is being done as this is the UCI spec. It will also lose Elo dependent on the testing conditions and tools used.

ELO   | -5.75 +- 4.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 11368 W: 2412 L: 2600 D: 6356