### PR TITLE
Don't update quiet histories when bestMove is Tactical

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -63,17 +63,19 @@ void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, i
   }
 
   // Update quiets
-  for (int i = 0; i < nQ; i++) {
-    Move m = quiets[i];
-    if (m != bestMove) {
-      AddHistoryHeuristic(&data->hh[stm][MoveStartEnd(m)], -inc);
-      if (parent)
-        AddHistoryHeuristic(
-            &data->ch[PIECE_TYPE[MovePiece(parent)]][MoveEnd(parent)][PIECE_TYPE[MovePiece(m)]][MoveEnd(m)], -inc);
-      if (grandParent)
-        AddHistoryHeuristic(
-            &data->fh[PIECE_TYPE[MovePiece(grandParent)]][MoveEnd(grandParent)][PIECE_TYPE[MovePiece(m)]][MoveEnd(m)],
-            -inc);
+  if (!Tactical(bestMove)) {
+    for (int i = 0; i < nQ; i++) {
+      Move m = quiets[i];
+      if (m != bestMove) {
+        AddHistoryHeuristic(&data->hh[stm][MoveStartEnd(m)], -inc);
+        if (parent)
+          AddHistoryHeuristic(
+              &data->ch[PIECE_TYPE[MovePiece(parent)]][MoveEnd(parent)][PIECE_TYPE[MovePiece(m)]][MoveEnd(m)], -inc);
+        if (grandParent)
+          AddHistoryHeuristic(
+              &data->fh[PIECE_TYPE[MovePiece(grandParent)]][MoveEnd(grandParent)][PIECE_TYPE[MovePiece(m)]][MoveEnd(m)],
+              -inc);
+      }
     }
   }
 

--- a/src/search.c
+++ b/src/search.c
@@ -479,7 +479,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
       if (totalMoves >= LMP[improving][depth])
         skipQuiets = 1;
 
-      if (!tactical && !specialQuiet && depth < 3 && counterHist <= -8192)
+      if (!tactical && !specialQuiet && depth < 3 && counterHist <= -4096)
         continue;
 
       if (!tactical && !board->checkers && eval + 100 * depth <= alpha && depth <= 8 &&
@@ -562,7 +562,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
           R++;
 
         // adjust reduction based on historical score
-        R -= quietHistory / 24576;
+        R -= quietHistory / 20480;
       } else {
         R--;
 


### PR DESCRIPTION
Bench: 6233790

ELO   | 2.43 +- 2.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 32712 W: 7360 L: 7131 D: 18221

ELO   | 2.32 +- 2.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 27864 W: 4510 L: 4324 D: 19030