### PR TITLE
Increase history bonus for moves that fail high above beta

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -29,6 +29,7 @@
 #include "move.h"
 #include "movegen.h"
 #include "movepick.h"
+#include "nn.h"
 #include "noobprobe/noobprobe.h"
 #include "pyrrhic/tbprobe.h"
 #include "search.h"
@@ -38,7 +39,7 @@
 #include "transposition.h"
 #include "types.h"
 #include "util.h"
-#include "nn.h"
+
 
 // arrays to store these pruning cutoffs at specific depths
 int LMR[MAX_SEARCH_PLY][64];
@@ -128,7 +129,7 @@ void* Search(void* arg) {
   SearchParams* params = thread->params;
   SearchResults* results = thread->results;
   Board* board = &thread->board;
-  
+
   int mainThread = !thread->idx;
   int searchStability = 0;
   int alpha = -CHECKMATE;
@@ -599,7 +600,8 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
       // we're failing high
       if (alpha >= beta) {
-        UpdateHistories(board, data, move, depth, board->side, quiets, numQuiets, tacticals, numTacticals);
+        UpdateHistories(board, data, move, depth + (bestScore > beta + 100), board->side, quiets, numQuiets, tacticals,
+                        numTacticals);
         break;
       }
     }


### PR DESCRIPTION
Bench: 5800250

ELO   | 10.07 +- 5.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5176 W: 1072 L: 922 D: 3182

ELO   | 5.08 +- 3.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10336 W: 1371 L: 1220 D: 7745