### PR TITLE
Depth 7 for major extensions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -503,7 +503,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     // moves at a shallow depth on a nullwindow that is somewhere below the tt evaluation
     // implemented using "skip move" recursion like in SF (allows for reductions when doing singular search)
     int extension = 0;
-    if (depth >= 8 && !skipMove && !isRoot && ttHit && move == tt->move && tt->depth >= depth - 3 &&
+    if (depth >= 7 && !skipMove && !isRoot && ttHit && move == tt->move && tt->depth >= depth - 3 &&
         abs(ttScore) < TB_WIN_BOUND && (tt->flags & TT_LOWER)) {
       int sBeta = max(ttScore - 3 * depth / 2, -CHECKMATE);
       int sDepth = depth / 2 - 1;
@@ -521,7 +521,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
 
     // history extension - if the tt move has a really good history score, extend.
     // thank you to Connor, author of Seer for this idea
-    else if (!isRoot && depth >= 8 && ttHit && move == tt->move && abs(ttScore) < TB_WIN_BOUND && quietHistory >= 98304)
+    else if (!isRoot && depth >= 7 && ttHit && move == tt->move && abs(ttScore) < TB_WIN_BOUND && quietHistory >= 98304)
       extension = 1;
 
     // re-capture extension - looks for a follow up capture on the same square
@@ -533,7 +533,7 @@ int Negamax(int alpha, int beta, int depth, ThreadData* thread, PV* pv) {
     MakeMove(move, board);
 
     // apply extensions
-    int newDepth = depth + max(extension, (board->checkers && depth < 8));
+    int newDepth = depth + max(extension, (board->checkers && depth < 7));
 
     // Late move reductions
     int R = 1;


### PR DESCRIPTION
Bench: 5961758

ELO   | 2.72 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 35568 W: 6587 L: 6309 D: 22672

ELO   | 1.30 +- 1.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 60208 W: 7246 L: 7021 D: 45941