### PR TITLE
Consecutive Fail Highs

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -134,6 +134,7 @@ void* Search(void* arg) {
   int alpha = -CHECKMATE;
   int beta = CHECKMATE;
   int score = 0;
+  int cfh = 0;
 
   board->ply = 0;
   ApplyFirstLayer(board, board->accumulators[WHITE][board->ply], WHITE);
@@ -179,14 +180,16 @@ void* Search(void* arg) {
             alpha = max(alpha - delta, -CHECKMATE);
 
             searchDepth = depth;
+            cfh = 0;
           } else if (score >= beta) {
             beta = min(beta + delta, CHECKMATE);
 
             if (abs(score) < TB_WIN_BOUND)
-              searchDepth--;
+              searchDepth = max(1, searchDepth - (++cfh));
           } else {
             thread->scores[thread->multiPV] = score;
             thread->bestMoves[thread->multiPV] = pv->moves[0];
+            cfh = 0;
             break;
           }
 


### PR DESCRIPTION
Bench: 4875882

ELO   | 7.43 +- 4.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6920 W: 1191 L: 1043 D: 4686

ELO   | 3.63 +- 2.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14848 W: 1650 L: 1495 D: 11703