### PR TITLE
Less reduction for pawn pushes to 7th rank

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -557,6 +557,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         if (specialQuiet)
           R -= 2;
 
+        if (PIECE_TYPE[MovePiece(move)] == PAWN_TYPE && rank(MoveEnd(move) ^ (board->xside == WHITE ? 0 : 56)) == 1)
+          R--;
+
         if (MoveCapture(nullThreat) && MoveStart(move) != MoveEnd(nullThreat) && !board->checkers)
           R++;
 


### PR DESCRIPTION
Bench: 3971595

ELO   | 2.73 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 30256 W: 4920 L: 4682 D: 20654