### PR TITLE
NMP returns null search score

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -249,7 +249,9 @@ void PrintBoard(Board* board) {
   printf("\nFEN: %s\n\n", fenBuffer);
 }
 
-inline int HasNonPawn(Board* board) { return (board->piecesCounts & NON_PAWN_PIECE_MASK[board->side]) != 0; }
+inline int HasNonPawn(Board* board) { 
+  return bits(board->occupancies[board->side] ^ board->pieces[KING[board->side]] ^ board->pieces[PAWN[board->side]]);
+}
 
 inline int IsOCB(Board* board) {
   BitBoard nonBishopMaterial = board->pieces[QUEEN_WHITE] | board->pieces[QUEEN_BLACK] | board->pieces[ROOK_WHITE] |

--- a/src/search.c
+++ b/src/search.c
@@ -408,7 +408,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // Null move pruning
     // i.e. Our position is so good we can give our opponnent a free move and
     // they still can't catch up (this is usually countered by captures or mate threats)
-    if (depth >= 3 && data->moves[data->ply - 1] != NULL_MOVE && !skipMove && eval >= beta && HasNonPawn(board)) {
+    if (depth >= 3 && data->moves[data->ply - 1] != NULL_MOVE && !skipMove && eval >= beta &&
+        // weiss conditional
+        HasNonPawn(board) > (depth > 8)) {
       int R = 4 + depth / 6 + min((eval - beta) / 256, 3);
       R = min(depth, R); // don't go too low
 
@@ -421,7 +423,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       data->ply--;
 
       if (score >= beta) {
-          return score < TB_WIN_BOUND ? score : beta;
+        return score < TB_WIN_BOUND ? score : beta;
       } else {
         nullThreat = childPv.count ? childPv.moves[0] : NULL_MOVE;
       }

--- a/src/search.c
+++ b/src/search.c
@@ -421,13 +421,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       data->ply--;
 
       if (score >= beta) {
-        if (depth <= 10)
           return score < TB_WIN_BOUND ? score : beta;
-
-        score = Negamax(beta - 1, beta, depth - R, 0, thread, pv);
-
-        if (score >= beta)
-          return score;
       } else {
         nullThreat = childPv.count ? childPv.moves[0] : NULL_MOVE;
       }
@@ -671,7 +665,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread, PV* pv) {
     return 0;
 
   // prevent overflows
-  if (data->ply > MAX_SEARCH_PLY - 1)
+  if (data->ply > MAX_SEARCH_PLY - 5)
     return Evaluate(board);
 
   // check the transposition table for previous info

--- a/src/search.c
+++ b/src/search.c
@@ -420,10 +420,17 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       UndoNullMove(board);
       data->ply--;
 
-      if (score >= beta)
-        return beta;
+      if (score >= beta) {
+        if (depth <= 10)
+          return score < TB_WIN_BOUND ? score : beta;
 
-      nullThreat = childPv.count ? childPv.moves[0] : NULL_MOVE;
+        score = Negamax(beta - 1, beta, depth - R, 0, thread, pv);
+
+        if (score >= beta)
+          return score;
+      } else {
+        nullThreat = childPv.count ? childPv.moves[0] : NULL_MOVE;
+      }
     }
 
     // Prob cut

--- a/src/search.c
+++ b/src/search.c
@@ -410,7 +410,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // they still can't catch up (this is usually countered by captures or mate threats)
     if (depth >= 3 && data->moves[data->ply - 1] != NULL_MOVE && !skipMove && eval >= beta &&
         // weiss conditional
-        HasNonPawn(board) > (depth > 8)) {
+        HasNonPawn(board) > (depth > 12)) {
       int R = 4 + depth / 6 + min((eval - beta) / 256, 3);
       R = min(depth, R); // don't go too low
 

--- a/src/search.c
+++ b/src/search.c
@@ -665,7 +665,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread, PV* pv) {
     return 0;
 
   // prevent overflows
-  if (data->ply > MAX_SEARCH_PLY - 5)
+  if (data->ply > MAX_SEARCH_PLY - 1)
     return Evaluate(board);
 
   // check the transposition table for previous info


### PR DESCRIPTION
Bench: 3881204

This patch also includes a minor fix on requiring multiple non-pawn pieces on the board when depth > 12.

ELO   | 10.94 +- 5.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4416 W: 775 L: 636 D: 3005