### PR TITLE
CFH Fix

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -134,7 +134,6 @@ void* Search(void* arg) {
   int alpha = -CHECKMATE;
   int beta = CHECKMATE;
   int score = 0;
-  int cfh = 0;
 
   board->ply = 0;
   RefreshAccumulator(board->accumulators[WHITE][board->ply], board, WHITE);
@@ -178,16 +177,16 @@ void* Search(void* arg) {
             alpha = max(alpha - delta, -CHECKMATE);
 
             searchDepth = depth;
-            cfh = 0;
           } else if (score >= beta) {
             beta = min(beta + delta, CHECKMATE);
 
-            if (abs(score) < TB_WIN_BOUND)
-              searchDepth = max(1, searchDepth - (++cfh));
+            if (abs(score) < TB_WIN_BOUND) {
+              searchDepth -= 2;
+              searchDepth = max(1, searchDepth);
+            }
           } else {
             thread->scores[thread->multiPV] = score;
             thread->bestMoves[thread->multiPV] = pv->moves[0];
-            cfh = 0;
             break;
           }
 

--- a/src/search.c
+++ b/src/search.c
@@ -183,7 +183,7 @@ void* Search(void* arg) {
             beta = min(beta + delta, CHECKMATE);
 
             if (abs(score) < TB_WIN_BOUND) {
-              cfh++;
+              cfh += 2;
               searchDepth -= cfh;
               searchDepth = max(1, searchDepth);
             }

--- a/src/search.c
+++ b/src/search.c
@@ -134,6 +134,7 @@ void* Search(void* arg) {
   int alpha = -CHECKMATE;
   int beta = CHECKMATE;
   int score = 0;
+  int cfh = 0;
 
   board->ply = 0;
   RefreshAccumulator(board->accumulators[WHITE][board->ply], board, WHITE);
@@ -177,16 +178,20 @@ void* Search(void* arg) {
             alpha = max(alpha - delta, -CHECKMATE);
 
             searchDepth = depth;
+            cfh = 0;
           } else if (score >= beta) {
             beta = min(beta + delta, CHECKMATE);
 
             if (abs(score) < TB_WIN_BOUND) {
-              searchDepth -= 2;
+              cfh++;
+              searchDepth -= cfh;
               searchDepth = max(1, searchDepth);
             }
           } else {
             thread->scores[thread->multiPV] = score;
             thread->bestMoves[thread->multiPV] = pv->moves[0];
+
+            cfh = 0;
             break;
           }
 


### PR DESCRIPTION
Bench: 3877920

It was identified that consecutive fail highs (CFH) were not working as intended. Attempts to change them to their intended behavior resulted in a loss of Elo. This path simply makes the behavior more visible and prevents a minor bug that caused root dropping into qsearch.

ELO   | 0.55 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 23528 W: 3530 L: 3493 D: 16505