### PR TITLE
Simplify Passed Pawn LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -558,9 +558,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         if (specialQuiet)
           R -= 2;
 
-        if (PIECE_TYPE[MovePiece(move)] == PAWN_TYPE && rank(MoveEnd(move) ^ (board->xside == WHITE ? 0 : 56)) == 1)
-          R--;
-
         if (board->checkers) // move GAVE check
           R--;
 


### PR DESCRIPTION
Bench: 3704258

ELO   | 0.51 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 23912 W: 3508 L: 3473 D: 16931