### PR TITLE
Tactical History in LMR Tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -546,8 +546,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         R -= quietHistory / 20480;
       } else {
         int th = GetTacticalHistory(data, board, move);
-
-        R = 1 - 4 * th / (abs(th) + 16384 + (8192 * isPV));
+        R = 1 - 4 * th / (abs(th) + 24576);
+        
+        R += cutnode;
       }
 
       // prevent dropping into QS, extending, or reducing all extensions


### PR DESCRIPTION
Bench: 3564880

ELO   | 2.26 +- 1.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 42672 W: 6496 L: 6219 D: 29957