### PR TITLE
Utilize Threats in Search

### DIFF
--- a/src/bits.h
+++ b/src/bits.h
@@ -17,6 +17,8 @@
 #ifndef BITS_H
 #define BITS_H
 
+#include <stdio.h>
+
 #include "types.h"
 #include "util.h"
 
@@ -67,6 +69,19 @@ INLINE int popAndGetLsb(BitBoard* bb) {
   int sq = lsb(*bb);
   popLsb(*bb);
   return sq;
+}
+
+INLINE void PrintBB(BitBoard bitboard) {
+  for (int i = 0; i < 64; i++) {
+    if ((i & 7) == 0) printf(" %d ", 8 - (i >> 3));
+
+    printf(" %d", getBit(bitboard, i) ? 1 : 0);
+
+    if ((i & 7) == 7) printf("\n");
+  }
+
+  printf("\n    a b c d e f g h\n\n");
+  printf(" Value: %" PRIu64 "\n\n", bitboard);
 }
 
 #endif

--- a/src/eval.c
+++ b/src/eval.c
@@ -18,12 +18,44 @@
 
 #include <stdio.h>
 
+#include "attacks.h"
+#include "bits.h"
 #include "board.h"
 #include "nn.h"
 #include "util.h"
 
 const int PHASE_VALUES[6] = {0, 3, 3, 5, 10, 0};
 const int MAX_PHASE = 64;
+
+// "Threats" logic to be utilized in search
+// idea originating in Koivisto
+BitBoard Threats(Board* board, int stm) {
+  int xstm = stm ^ 1;
+
+  BitBoard threatened = 0;
+  BitBoard opponentPieces = OccBB(xstm) & ~PieceBB(PAWN, xstm);
+
+  BitBoard pawnAttacks = stm == WHITE ? ShiftNW(PieceBB(PAWN, WHITE)) | ShiftNE(PieceBB(PAWN, WHITE))
+                                      : ShiftSW(PieceBB(PAWN, BLACK)) | ShiftSE(PieceBB(PAWN, BLACK));
+  threatened |= pawnAttacks & opponentPieces;
+
+  // remove minors
+  opponentPieces &= ~(PieceBB(KNIGHT, xstm) | PieceBB(BISHOP, xstm));
+
+  BitBoard knights = PieceBB(KNIGHT, stm);
+  while (knights) threatened |= opponentPieces & GetKnightAttacks(popAndGetLsb(&knights));
+
+  BitBoard bishops = PieceBB(BISHOP, stm);
+  while (bishops) threatened |= opponentPieces & GetBishopAttacks(popAndGetLsb(&bishops), OccBB(BOTH));
+
+  // remove rooks
+  opponentPieces &= ~PieceBB(ROOK, xstm);
+
+  BitBoard rooks = PieceBB(ROOK, stm);
+  while (rooks) threatened |= opponentPieces & GetRookAttacks(popAndGetLsb(&rooks), OccBB(BOTH));
+
+  return threatened;
+}
 
 // Main evalution method
 Score Evaluate(Board* board) {

--- a/src/eval.h
+++ b/src/eval.h
@@ -24,6 +24,7 @@
 extern const int PHASE_VALUES[6];
 extern const int MAX_PHASE;
 
+BitBoard Threats(Board* board, int stm);
 Score Evaluate(Board* board);
 
 #endif

--- a/src/history.c
+++ b/src/history.c
@@ -33,7 +33,7 @@ void AddCounterMove(SearchData* data, Move move, Move parent) { data->counters[F
 void AddHistoryHeuristic(int* entry, int inc) { *entry += 64 * inc - *entry * abs(inc) / 1024; }
 
 void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, int stm, Move quiets[], int nQ,
-                     Move tacticals[], int nT) {
+                     Move tacticals[], int nT, BitBoard threats) {
   int inc = min(depth * depth, 576);
 
   Move parent = data->ply > 0 ? data->moves[data->ply - 1] : NULL_MOVE;
@@ -41,7 +41,7 @@ void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, i
 
   if (!IsTactical(bestMove)) {
     AddKillerMove(data, bestMove);
-    AddHistoryHeuristic(&HH(stm, bestMove), inc);
+    AddHistoryHeuristic(&HH(stm, bestMove, threats), inc);
 
     if (parent) {
       AddCounterMove(data, bestMove, parent);
@@ -62,7 +62,7 @@ void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, i
     for (int i = 0; i < nQ; i++) {
       Move m = quiets[i];
       if (m != bestMove) {
-        AddHistoryHeuristic(&HH(stm, m), -inc);
+        AddHistoryHeuristic(&HH(stm, m, threats), -inc);
         if (parent) AddHistoryHeuristic(&CH(parent, m), -inc);
         if (grandParent) AddHistoryHeuristic(&FH(grandParent, m), -inc);
       }
@@ -83,8 +83,8 @@ void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, i
   }
 }
 
-int GetQuietHistory(SearchData* data, Move move, int stm) {
-  int history = HH(stm, move);
+int GetQuietHistory(SearchData* data, Move move, int stm, BitBoard threats) {
+  int history = HH(stm, move, threats);
 
   Move parent = data->ply > 0 ? data->moves[data->ply - 1] : NULL_MOVE;
   if (parent) history += CH(parent, move);

--- a/src/history.h
+++ b/src/history.h
@@ -17,9 +17,10 @@
 #ifndef HISTORY_H
 #define HISTORY_H
 
+#include "bits.h"
 #include "types.h"
 
-#define HH(stm, m) (data->hh[stm][FromTo(m)])
+#define HH(stm, m, threats) (data->hh[stm][threats ? lsb(threats) : 64][FromTo(m)])
 #define CH(p, m) (data->ch[PieceType(Moving(p))][To(p)][PieceType(Moving(m))][To(m)])
 #define FH(g, m) (data->fh[PieceType(Moving(g))][To(g)][PieceType(Moving(m))][To(m)])
 #define TH(p, e, c) (data->th[p][e][c])
@@ -28,8 +29,8 @@ void AddKillerMove(SearchData* data, Move move);
 void AddCounterMove(SearchData* data, Move move, Move parent);
 void AddHistoryHeuristic(int* entry, int inc);
 void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, int stm, Move quiets[], int nQ,
-                     Move tacticals[], int nT);
-int GetQuietHistory(SearchData* data, Move move, int stm);
+                     Move tacticals[], int nT, BitBoard threats);
+int GetQuietHistory(SearchData* data, Move move, int stm, BitBoard threats);
 int GetCounterHistory(SearchData* data, Move move);
 int GetTacticalHistory(SearchData* data, Board* board, Move move);
 

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -29,13 +29,14 @@
 
 const int MATERIAL_VALUES[7] = {100, 325, 325, 550, 1100, 0, 0};
 
-void InitAllMoves(MoveList* moves, Move hashMove, SearchData* data) {
+void InitAllMoves(MoveList* moves, Move hashMove, SearchData* data, BitBoard threats) {
   moves->type = ALL_MOVES;
   moves->phase = HASH_MOVE;
   moves->nTactical = 0;
   moves->nQuiets = 0;
   moves->nBadTactical = 0;
   moves->seeCutoff = 0;
+  moves->threats = threats;
 
   moves->hashMove = hashMove;
   moves->killer1 = data->killers[data->ply][0];
@@ -54,6 +55,7 @@ void InitTacticalMoves(MoveList* moves, SearchData* data, int cutoff) {
   moves->nQuiets = 0;
   moves->nBadTactical = 0;
   moves->seeCutoff = cutoff;
+  moves->threats = 0;
 
   moves->hashMove = NULL_MOVE;
   moves->killer1 = NULL_MOVE;
@@ -143,7 +145,7 @@ void ScoreQuietMoves(MoveList* moves, Board* board, SearchData* data) {
   for (int i = 0; i < moves->nQuiets; i++) {
     Move m = moves->quiet[i];
 
-    moves->sQuiet[i] = GetQuietHistory(data, m, board->stm);
+    moves->sQuiet[i] = GetQuietHistory(data, m, board->stm, moves->threats);
   }
 }
 
@@ -298,7 +300,7 @@ void PrintMoves(Board* board, ThreadData* thread) {
 
   thread->data.ply = 0;
   MoveList list = {0};
-  InitAllMoves(&list, hit ? tt->move : NULL_MOVE, &thread->data);
+  InitAllMoves(&list, hit ? tt->move : NULL_MOVE, &thread->data, Threats(board, board->xstm));
 
   int i = 1;
   Move move;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -19,7 +19,7 @@
 
 #include "types.h"
 
-void InitAllMoves(MoveList* moves, Move hashMove, SearchData* data);
+void InitAllMoves(MoveList* moves, Move hashMove, SearchData* data, BitBoard threats);
 void InitTacticalMoves(MoveList* moves, SearchData* data, int cutoff);
 void InitPerftMoves(MoveList* moves, Board* board);
 Move NextMove(MoveList* moves, Board* board, int skipQuiets);

--- a/src/search.c
+++ b/src/search.c
@@ -390,16 +390,18 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (tt->flags & (ttScore > eval ? TT_LOWER : TT_UPPER)) eval = ttScore;
     }
 
+    BitBoard oppThreats = Threats(board, board->xstm);
+
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
-    if (depth <= 6 && !skipMove && eval - 50 * (depth - (improving && !Threats(board, board->xstm))) - 10 >= beta &&
-        eval < TB_WIN_BOUND)
+    if (depth <= 6 && !skipMove && eval - 50 * (depth - (improving && !oppThreats)) - 10 >= beta && eval < TB_WIN_BOUND)
       return eval;
 
     // Null move pruning
     // i.e. Our position is so good we can give our opponnent a free move and
     // they still can't catch up (this is usually countered by captures or mate threats)
-    if (depth >= 3 && data->moves[data->ply - 1] != NULL_MOVE && !skipMove && eval - 10 * improving >= beta &&
+    if (depth >= 5 - 2 * !oppThreats && data->moves[data->ply - 1] != NULL_MOVE && !skipMove &&
+        eval - 10 * improving >= beta &&
         // weiss conditional
         HasNonPawn(board) > (depth > 12)) {
       int R = 4 + depth / 6 + min((eval - beta) / 256, 3);

--- a/src/search.c
+++ b/src/search.c
@@ -392,7 +392,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
-    if (depth <= 6 && !skipMove && eval - 50 * (depth - improving) - 10 >= beta && eval < TB_WIN_BOUND)
+    if (depth <= 6 && bits(Threats(board, board->xstm)) < 2 && !skipMove &&
+        eval - 50 * (depth - improving) - 10 >= beta && eval < TB_WIN_BOUND)
       return eval;
 
     // Null move pruning
@@ -547,7 +548,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       } else {
         int th = GetTacticalHistory(data, board, move);
         R = 1 - 4 * th / (abs(th) + 24576);
-        
+
         R += cutnode;
       }
 

--- a/src/search.c
+++ b/src/search.c
@@ -400,7 +400,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // Null move pruning
     // i.e. Our position is so good we can give our opponnent a free move and
     // they still can't catch up (this is usually countered by captures or mate threats)
-    if (depth >= 5 * !!oppThreats && data->moves[data->ply - 1] != NULL_MOVE && !skipMove &&
+    if (depth >= 8 - 5 * !oppThreats && data->moves[data->ply - 1] != NULL_MOVE && !skipMove &&
         eval - 10 * improving >= beta &&
         // weiss conditional
         HasNonPawn(board) > (depth > 12)) {

--- a/src/search.c
+++ b/src/search.c
@@ -400,7 +400,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // Null move pruning
     // i.e. Our position is so good we can give our opponnent a free move and
     // they still can't catch up (this is usually countered by captures or mate threats)
-    if (depth >= 5 - 2 * !oppThreats && data->moves[data->ply - 1] != NULL_MOVE && !skipMove &&
+    if (depth >= 5 * !!oppThreats && data->moves[data->ply - 1] != NULL_MOVE && !skipMove &&
         eval - 10 * improving >= beta &&
         // weiss conditional
         HasNonPawn(board) > (depth > 12)) {

--- a/src/search.c
+++ b/src/search.c
@@ -392,8 +392,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
-    if (depth <= 6 && bits(Threats(board, board->xstm)) < 2 && !skipMove &&
-        eval - 50 * (depth - improving) - 10 >= beta && eval < TB_WIN_BOUND)
+    if (depth <= 6 && !skipMove && eval - 50 * (depth - (improving && !Threats(board, board->xstm))) - 10 >= beta &&
+        eval < TB_WIN_BOUND)
       return eval;
 
     // Null move pruning

--- a/src/search.c
+++ b/src/search.c
@@ -384,14 +384,13 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   data->killers[data->ply + 1][0] = NULL_MOVE;
   data->killers[data->ply + 1][1] = NULL_MOVE;
 
+  BitBoard oppThreats = Threats(board, board->xstm);
+
   if (!isPV && !board->checkers) {
     // Our TT might have a more accurate evaluation score, use this
     if (ttHit && tt->depth >= depth && ttScore != UNKNOWN) {
       if (tt->flags & (ttScore > eval ? TT_LOWER : TT_UPPER)) eval = ttScore;
     }
-
-    BitBoard oppThreats = Threats(board, board->xstm);
-    BitBoard ownThreats = Threats(board, board->stm);
 
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
@@ -421,6 +420,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // Prob cut
     // If a relatively deep search from our TT doesn't say this node is
     // less than beta + margin, then we run a shallow search to look
+    BitBoard ownThreats = Threats(board, board->stm);
     int probBeta = beta + 110;
     if (depth > 4 && abs(beta) < TB_WIN_BOUND && ownThreats && !(ttHit && tt->depth >= depth - 3 && ttScore < probBeta)) {
       InitTacticalMoves(&moves, data, 0);
@@ -448,7 +448,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   Move tacticals[64];
 
   int totalMoves = 0, nonPrunedMoves = 0, numQuiets = 0, skipQuiets = 0, numTacticals = 0;
-  InitAllMoves(&moves, hashMove, data);
+  InitAllMoves(&moves, hashMove, data, oppThreats);
 
   while ((move = NextMove(&moves, board, skipQuiets))) {
     if (isRoot && MoveSearchedByMultiPV(thread, move)) continue;
@@ -461,7 +461,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     int tactical = !!IsTactical(move);
     int specialQuiet = !tactical && (move == moves.killer1 || move == moves.killer2 || move == moves.counter);
-    int quietHistory = !tactical ? GetQuietHistory(data, move, board->stm) : 0;
+    int quietHistory = !tactical ? GetQuietHistory(data, move, board->stm, oppThreats) : 0;
     int counterHist = !tactical ? GetCounterHistory(data, move) : 0;
 
     if (bestScore > -MATE_BOUND) {
@@ -590,7 +590,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // we're failing high
       if (alpha >= beta) {
         UpdateHistories(board, data, move, depth + (bestScore > beta + 100), board->stm, quiets, numQuiets, tacticals,
-                        numTacticals);
+                        numTacticals, oppThreats);
         break;
       }
     }

--- a/src/search.c
+++ b/src/search.c
@@ -391,6 +391,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     }
 
     BitBoard oppThreats = Threats(board, board->xstm);
+    BitBoard ownThreats = Threats(board, board->stm);
 
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
@@ -400,8 +401,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // Null move pruning
     // i.e. Our position is so good we can give our opponnent a free move and
     // they still can't catch up (this is usually countered by captures or mate threats)
-    if (depth >= 8 - 5 * !oppThreats && data->moves[data->ply - 1] != NULL_MOVE && !skipMove &&
-        eval - 10 * improving >= beta &&
+    if (depth >= 3 && data->moves[data->ply - 1] != NULL_MOVE && !skipMove && eval - 10 * improving >= beta &&
         // weiss conditional
         HasNonPawn(board) > (depth > 12)) {
       int R = 4 + depth / 6 + min((eval - beta) / 256, 3);
@@ -422,7 +422,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // If a relatively deep search from our TT doesn't say this node is
     // less than beta + margin, then we run a shallow search to look
     int probBeta = beta + 110;
-    if (depth > 4 && abs(beta) < TB_WIN_BOUND && !(ttHit && tt->depth >= depth - 3 && ttScore < probBeta)) {
+    if (depth > 4 && abs(beta) < TB_WIN_BOUND && ownThreats && !(ttHit && tt->depth >= depth - 3 && ttScore < probBeta)) {
       InitTacticalMoves(&moves, data, 0);
       while ((move = NextMove(&moves, board, 1))) {
         if (skipMove == move) continue;

--- a/src/types.h
+++ b/src/types.h
@@ -108,7 +108,7 @@ typedef struct {
 
   Move killers[MAX_SEARCH_PLY][2];  // killer moves, 2 per ply
   Move counters[64 * 64];           // counter move butterfly table
-  int hh[2][64 * 64];               // history heuristic butterfly table (stm)
+  int hh[2][65][64 * 64];           // history heuristic butterfly table (stm)
   int ch[6][64][6][64];             // counter move history table
   int fh[6][64][6][64];             // follow up history table
 
@@ -187,6 +187,8 @@ typedef struct {
   Move hashMove, killer1, killer2, counter;
   int seeCutoff;
   uint8_t type, phase, nTactical, nQuiets, nBadTactical;
+
+  BitBoard threats;
 
   Move tactical[MAX_MOVES];
   Move quiet[MAX_MOVES];

--- a/src/uci.c
+++ b/src/uci.c
@@ -251,6 +251,8 @@ void UCILoop() {
       PONDERING = 0;
     } else if (!strncmp(in, "board", 5)) {
       PrintBoard(&board);
+    } else if (!strncmp(in, "threats", 7)) {
+      PrintBB(Threats(&board, board.stm));
     } else if (!strncmp(in, "eval", 4)) {
       int score = Predict(&board);
       score = board.stm == WHITE ? score : -score;


### PR DESCRIPTION
Bench: 3384186

Idea's from Koivisto and Seer

Threat History

ELO   | 2.57 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 30512 W: 4359 L: 4133 D: 22020

Probcut Speedup

ELO   | 7.33 +- 4.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6776 W: 1014 L: 871 D: 4891

RFP Improvement
ELO   | 4.65 +- 3.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12192 W: 1810 L: 1647 D: 8735