### PR TITLE
Recapture Extension with Intermediate Move

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -81,6 +81,7 @@ char* MoveToStr(Move move, Board* board) {
 
 inline int IsRecapture(SearchData* data, Move move) {
   Move parent = data->moves[data->ply - 1];
+  Move greatGrandParent = data->ply > 2 ? data->moves[data->ply - 3] : NULL_MOVE;
 
-  return !(IsCap(parent) ^ IsCap(move)) && To(parent) == To(move);
+  return (IsCap(parent) && To(parent) == To(move)) || (IsCap(greatGrandParent) && To(greatGrandParent) == To(move));
 }


### PR DESCRIPTION
Bench: 3824553

ELO   | 3.51 +- 2.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 18792 W: 2849 L: 2659 D: 13284