### PR TITLE
Use PV for TT Move at Root

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -312,10 +312,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   // we ignore the tt on singular extension searches
   int ttHit = 0;
   TTEntry* tt = skipMove ? NULL : TTProbe(&ttHit, board->zobrist);
-  if (ttHit) {
-    hashMove = tt->move;
-    ttScore = TTScore(tt, data->ply);
-  }
+  ttScore = ttHit ? TTScore(tt, data->ply) : UNKNOWN;
+  hashMove = isRoot ? thread->pvs[thread->multiPV].moves[0] : ttHit ? tt->move : NULL_MOVE;
 
   // if the TT has a value that fits our position and has been searched to an equal or greater depth, then we accept
   // this score and prune

--- a/src/thread.c
+++ b/src/thread.c
@@ -64,7 +64,10 @@ void InitPool(Board* board, SearchParams* params, ThreadData* threads, SearchRes
     memset(&threads[i].data.skipMove, 0, sizeof(threads[i].data.skipMove));
     memset(&threads[i].data.evals, 0, sizeof(threads[i].data.evals));
     memset(&threads[i].data.moves, 0, sizeof(threads[i].data.moves));
+    
     memset(&threads[i].scores, 0, sizeof(threads[i].scores));
+    memset(&threads[i].bestMoves, 0, sizeof(threads[i].bestMoves));
+    memset(&threads[i].pvs, 0, sizeof(threads[i].pvs));
 
     // need full copies of the board
     memcpy(&threads[i].board, board, sizeof(Board));


### PR DESCRIPTION
Bench: 3480356

ELO   | 0.41 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 55496 W: 13652 L: 13586 D: 28258

ELO   | 1.54 +- 1.53 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 0.46 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 92104 W: 21811 L: 21404 D: 48889