### PR TITLE
Use history value in Futility Pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -474,7 +474,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (!tactical) {
         if (depth < 3 && !killerOrCounter && (history < -4096 * depth || counterHistory < -2048 * depth)) continue;
 
-        if (depth < 9 && eval + 100 * depth <= alpha && history < 50000 / (1 + improving)) skipQuiets = 1;
+        if (depth < 9 && eval + 100 + 50 * depth + history / 512 <= alpha) skipQuiets = 1;
 
         if (SEE(board, move) < STATIC_PRUNE[0][depth]) continue;
       } else {


### PR DESCRIPTION
Bench: 3749935

ELO   | 4.34 +- 3.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 20584 W: 5122 L: 4865 D: 10597