### PR TITLE
Prevent base allocation time from getting too high

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -127,7 +127,7 @@ void ParseGo(char* in, SearchParams* params, Board* board, ThreadData* threads) 
 
       int total = max(1, time + movesToGo * inc - MOVE_OVERHEAD);
 
-      params->alloc = total / 20.0;
+      params->alloc = min(time * 0.33, total / 20.0);
       params->max = min(time * 0.75, params->alloc * 5.5);
     } else {
       // no time control


### PR DESCRIPTION
Bench: 3172446

ELO   | 5.79 +- 5.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 6120 W: 1482 L: 1380 D: 3258