### PR TITLE
Utilize node count statistics with move stability

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -63,6 +63,7 @@ void InitPool(Board* board, SearchParams* params, ThreadData* threads, SearchRes
     // empty unneeded data
     memset(&threads[i].data.skipMove, 0, sizeof(threads[i].data.skipMove));
     memset(&threads[i].data.evals, 0, sizeof(threads[i].data.evals));
+    memset(&threads[i].data.tm, 0, sizeof(threads[i].data.tm));
 
     // set the moves arr as an offset of 2
     memset(&threads[i].data.searchMoves, 0, sizeof(threads[i].data.searchMoves));

--- a/src/types.h
+++ b/src/types.h
@@ -115,6 +115,8 @@ typedef struct {
   int fh[6][64][6][64];             // follow up history table
 
   int th[6][64][6];  // tactical (capture) history
+
+  int64_t tm[64 * 64];
 } SearchData;
 
 typedef struct {


### PR DESCRIPTION
Bench: 3126114

ELO   | 5.13 +- 3.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 15728 W: 3754 L: 3522 D: 8452

ELO   | 6.68 +- 4.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 10712 W: 2438 L: 2232 D: 6042