### PR TITLE
Apply Check Extension only before QSearch

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -288,7 +288,12 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   MoveList moves;
 
   // drop into tactical moves only
-  if (depth <= 0) return Quiesce(alpha, beta, thread);
+  if (depth <= 0) {
+    if (board->checkers)
+      depth = 1;
+    else
+      return Quiesce(alpha, beta, thread);
+  }
 
   data->nodes++;
   data->seldepth = max(data->ply, data->seldepth);
@@ -533,9 +538,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     data->moves[data->ply++] = move;
     MakeMove(move, board);
-
-    // check extension applied at low depths
-    if (!extension && board->checkers && depth < 7) extension = 1;
 
     // apply extensions
     int newDepth = depth + extension;


### PR DESCRIPTION
Bench: 3498487

ELO   | 2.84 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 41784 W: 9946 L: 9605 D: 22233