### PR TITLE
Simplify SEE value based on static eval

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -694,8 +694,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
   Move move;
   MoveList moves;
 
-  int seeThreshold = max(0, alpha - eval - DELTA_CUTOFF);
-  InitTacticalMoves(&moves, data, seeThreshold);
+  InitTacticalMoves(&moves, data, eval <= alpha - DELTA_CUTOFF);
 
   while ((move = NextMove(&moves, board, 1))) {
     if (moves.phase > PLAY_GOOD_TACTICAL) break;

--- a/src/search.h
+++ b/src/search.h
@@ -33,7 +33,7 @@
 #define SEE_PRUNE_CUTOFF 15
 
 // delta pruning in QS
-#define DELTA_CUTOFF 150
+#define DELTA_CUTOFF 50
 
 // base window value
 #define WINDOW 10


### PR DESCRIPTION
Bench: 3278368

ELO   | 3.20 +- 4.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 9456 W: 2246 L: 2159 D: 5051