### PR TITLE
Support "go nodes N"

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -36,7 +36,7 @@ char* benchmarks[] = {
 
 void Bench() {
   Board board;
-  SearchParams params = {.depth = 13, .multiPV = 1};
+  SearchParams params = {.depth = 13, .multiPV = 1, .hitrate = 1024};
   ThreadData* threads = CreatePool(1);
 
   Move bestMoves[NUM_BENCH_POSITIONS];

--- a/src/types.h
+++ b/src/types.h
@@ -133,6 +133,10 @@ typedef struct {
   int quit;
   int multiPV;
   int searchMoves;
+
+  int hitrate;
+  uint64_t nodes;
+  
   SimpleMoveList searchable;
 } SearchParams;
 


### PR DESCRIPTION
Bench: 4218509

Tested with a really fast TC where the slow downs of the additional logic will present the most impact.

ELO   | -0.25 +- 2.01 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 38200 W: 6332 L: 6360 D: 25508