### PR TITLE
UCI Contempt

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -30,7 +30,7 @@ const int PHASE_VALUES[6] = {0, 3, 3, 5, 10, 0};
 const int MAX_PHASE = 64;
 
 void SetContempt(int* dest, int stm, int score) {
-  int contempt = 40 * score / (abs(score) + 120);
+  int contempt = CONTEMPT + 40 * score / (abs(score) + 120);
 
   dest[stm] = contempt;
   dest[stm ^ 1] = -contempt;

--- a/src/uci.c
+++ b/src/uci.c
@@ -42,6 +42,7 @@ int MOVE_OVERHEAD = 300;
 int MULTI_PV = 1;
 int PONDER_ENABLED = 0;
 int CHESS_960 = 0;
+int CONTEMPT = 0;
 volatile int PONDERING = 0;
 
 void RootMoves(SimpleMoveList* moves, Board* board) {
@@ -205,6 +206,7 @@ void PrintUCIOptions() {
   printf("option name Ponder type check default false\n");
   printf("option name UCI_Chess960 type check default false\n");
   printf("option name MoveOverhead type spin default 300 min 100 max 10000\n");
+  printf("option name Contempt type spin default 0 min -100 max 100\n");
   printf("uciok\n");
 }
 
@@ -369,6 +371,8 @@ void UCILoop() {
       failedQueries = 0;
     } else if (!strncmp(in, "setoption name MoveOverhead value ", 34)) {
       MOVE_OVERHEAD = min(10000, max(100, GetOptionIntValue(in)));
+    } else if (!strncmp(in, "setoption name Contempt value ", 30)) {
+      CONTEMPT = min(100, max(-100, GetOptionIntValue(in)));
     }
   }
 }

--- a/src/uci.c
+++ b/src/uci.c
@@ -42,7 +42,7 @@ int MOVE_OVERHEAD = 300;
 int MULTI_PV = 1;
 int PONDER_ENABLED = 0;
 int CHESS_960 = 0;
-int CONTEMPT = 0;
+int CONTEMPT = 12;
 volatile int PONDERING = 0;
 
 void RootMoves(SimpleMoveList* moves, Board* board) {
@@ -206,7 +206,7 @@ void PrintUCIOptions() {
   printf("option name Ponder type check default false\n");
   printf("option name UCI_Chess960 type check default false\n");
   printf("option name MoveOverhead type spin default 300 min 100 max 10000\n");
-  printf("option name Contempt type spin default 0 min -100 max 100\n");
+  printf("option name Contempt type spin default 12 min -100 max 100\n");
   printf("uciok\n");
 }
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -20,6 +20,7 @@
 #include "types.h"
 
 extern int CHESS_960;
+extern int CONTEMPT;
 
 void RootMoves(SimpleMoveList* moves, Board* board);
 


### PR DESCRIPTION
Bench: 3872658

Default set to 12, which presented nearly as well as 24 in testing, and is a much safer bet against equal or better engines.

Loses no Elo in equal matchup
```
ELO   | 0.15 +- 3.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 23656 W: 5845 L: 5835 D: 11976
```

Presents ~6 Elo vs weaker engines (test vs Berserk 8)
```
ELO   | 79.94 +- 2.94 (95%)
CONF  | 8.0+0.08s Threads=1 Hash=8MB
GAMES | N: 20000 W: 6131 L: 1609 D: 12260

ELO   | 86.48 +- 3.05 (95%)
CONF  | 8.0+0.08s Threads=1 Hash=8MB
GAMES | N: 20000 W: 6588 L: 1710 D: 11702
```
