### PR TITLE
Adjust feature indexing

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -32,9 +32,45 @@
 #include "uci.h"
 #include "zobrist.h"
 
-const int8_t PSQT[] = {0,  1,  2,  3,  3,  2,  1,  0,  4,  5,  6,  7,  7,  6,  5,  4,  8,  9,  10, 11, 11, 10,
-                       9,  8,  12, 13, 14, 15, 15, 14, 13, 12, 16, 17, 18, 19, 19, 18, 17, 16, 20, 21, 22, 23,
-                       23, 22, 21, 20, 24, 25, 26, 27, 27, 26, 25, 24, 28, 29, 30, 31, 31, 30, 29, 28};
+const int8_t PSQT[] = {
+    0,  1,  2,  3,  3,  2,  1,  0,   // 1
+    4,  5,  6,  7,  7,  6,  5,  4,   // 2
+    8,  9,  10, 11, 11, 10, 9,  8,   // 3
+    12, 13, 14, 15, 15, 14, 13, 12,  // 4
+    16, 17, 18, 19, 19, 18, 17, 16,  // 5
+    20, 21, 22, 23, 23, 22, 21, 20,  // 6
+    24, 25, 26, 27, 27, 26, 25, 24,  // 7
+    28, 29, 30, 31, 31, 30, 29, 28   // 8
+};
+
+const int16_t PC_FEATURE_OFFSET[2][12] = {{
+                                              0,    // WHITE_PAWN
+                                              384,  // BLACK_PAWN
+                                              64,   // WHITE_KNIGHT
+                                              448,  // BLACK_KNIGHT
+                                              128,  // WHITE_BISHOP
+                                              512,  // BLACK_BISHOP
+                                              192,  // WHITE_ROOK
+                                              576,  // BLACK_ROOK
+                                              256,  // WHITE_QUEEN
+                                              640,  // BLACK_QUEEN
+                                              320,  // WHITE_KING
+                                              704,  // BLACK_KING
+                                          },
+                                          {
+                                              384,  // WHITE_PAWN
+                                              0,    // BLACK_PAWN
+                                              448,  // WHITE_KNIGHT
+                                              64,   // BLACK_KNIGHT
+                                              512,  // WHITE_BISHOP
+                                              128,  // BLACK_BISHOP
+                                              576,  // WHITE_ROOK
+                                              192,  // BLACK_ROOK
+                                              640,  // WHITE_QUEEN
+                                              256,  // BLACK_QUEEN
+                                              704,  // WHITE_KING
+                                              320,  // BLACK_KING
+                                          }};
 
 // piece count key bit mask idx
 const uint64_t PIECE_COUNT_IDX[] = {1ULL << 0,  1ULL << 4,  1ULL << 8,  1ULL << 12, 1ULL << 16,

--- a/src/board.h
+++ b/src/board.h
@@ -32,6 +32,7 @@
 #define Sq(r, f) ((r)*8 + (f))
 
 extern const int8_t PSQT[];
+extern const int16_t PC_FEATURE_OFFSET[2][12];
 
 extern const uint64_t PIECE_COUNT_IDX[];
 
@@ -62,15 +63,9 @@ int MoveIsLegal(Move move, Board* board);
 INLINE int KingIdx(int k, int s) { return (k & 4) == (s & 4); }
 
 INLINE int FeatureIdx(int piece, int sq, int kingsq, const int perspective) {
-  if (perspective == WHITE) {
-    int pc = piece / 2 + 6 * !!(piece & 1);
-
-    return pc * 64 + KingIdx(kingsq, sq) * 32 + PSQT[sq ^ 56];
-  } else {
-    int pc = piece / 2 + 6 * !(piece & 1);
-
-    return pc * 64 + KingIdx(kingsq, sq) * 32 + PSQT[sq];
-  }
+  return PC_FEATURE_OFFSET[perspective][piece]        // Base piece offset
+         + KingIdx(kingsq, sq) * 32                   // index based on same side as king
+         + PSQT[sq ^ (56 * (perspective == WHITE))];  // convert square to half psqt
 }
 
 #endif


### PR DESCRIPTION
Bench: 4123350

ELO   | 1.64 +- 4.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 13552 W: 3381 L: 3317 D: 6854