### PR TITLE
Disable SE and HE for winning positions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -521,7 +521,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // and look at it more (extend). Singular is determined by checking all other
     // moves at a shallow depth on a nullwindow that is somewhere below the tt evaluation
     // implemented using "skip move" recursion like in SF (allows for reductions when doing singular search)
-    if (!isRoot && depth >= 7 && ttHit && move == tt->move && tt->depth >= depth - 3 && abs(ttScore) < TB_WIN_BOUND &&
+    if (!isRoot && depth >= 7 && ttHit && move == tt->move && tt->depth >= depth - 3 && abs(ttScore) <= 400 &&
         (tt->flags & TT_LOWER)) {
       int sBeta = max(ttScore - 3 * depth / 2, -CHECKMATE);
       int sDepth = depth / 2 - 1;
@@ -539,7 +539,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     // history extension - if the tt move has a really good history score, extend.
     // thank you to Connor, author of Seer for this idea
-    else if (!isRoot && depth >= 7 && ttHit && move == tt->move && abs(ttScore) < TB_WIN_BOUND && history >= 98304)
+    else if (!isRoot && depth >= 7 && ttHit && move == tt->move && abs(ttScore) <= 400 && history >= 98304)
       extension = 1;
 
     // re-capture extension - looks for a follow up capture on the same square


### PR DESCRIPTION
Bench: 3725004

ELO   | 2.92 +- 2.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 40744 W: 10141 L: 9798 D: 20805

ELO   | 2.81 +- 2.84 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 26752 W: 6333 L: 6117 D: 14302