### PR TITLE
Remove dynamic contempt

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -29,8 +29,8 @@
 const int PHASE_VALUES[6] = {0, 3, 3, 5, 10, 0};
 const int MAX_PHASE = 64;
 
-void SetContempt(int* dest, int stm, int score) {
-  int contempt = CONTEMPT + 40 * score / (abs(score) + 120);
+void SetContempt(int* dest, int stm) {
+  int contempt = CONTEMPT;
 
   dest[stm] = contempt;
   dest[stm ^ 1] = -contempt;

--- a/src/eval.h
+++ b/src/eval.h
@@ -24,7 +24,7 @@
 extern const int PHASE_VALUES[6];
 extern const int MAX_PHASE;
 
-void SetContempt(int* dest, int stm, int score);
+void SetContempt(int* dest, int stm);
 BitBoard Threats(Board* board, int stm);
 Score Evaluate(Board* board, ThreadData* thread);
 

--- a/src/search.c
+++ b/src/search.c
@@ -142,6 +142,7 @@ void* Search(void* arg) {
   RefreshAccumulator(board->accumulators[BLACK][board->ply], board, BLACK);
 
   data->contempt[WHITE] = data->contempt[BLACK] = 0;
+  SetContempt(data->contempt, board->stm);
 
   // set a hot exit point for this thread
   if (!setjmp(thread->exit)) {
@@ -169,8 +170,6 @@ void* Search(void* arg) {
           beta = min(score + WINDOW, CHECKMATE);
           delta = WINDOW;
         }
-
-        SetContempt(data->contempt, board->stm, score);
 
         while (!params->stopped) {
           data->window = beta - alpha;


### PR DESCRIPTION
Bench: 4097487

ELO   | -0.05 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 26288 W: 6393 L: 6397 D: 13498