### PR TITLE
Tune static exchange evaluation values with CTT

### DIFF
--- a/src/see.c
+++ b/src/see.c
@@ -24,7 +24,7 @@
 #include "types.h"
 #include "util.h"
 
-const int SEE_VALUE[7] = {100, 425, 425, 645, 870, 30000, 0};
+const int SEE_VALUE[7] = {100, 414, 414, 621, 1005, 30000, 0};
 
 // Static exchange evaluation using The Swap Algorithm - https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm
 inline int SEE(Board* board, Move move, int threshold) {

--- a/src/see.c
+++ b/src/see.c
@@ -24,7 +24,7 @@
 #include "types.h"
 #include "util.h"
 
-const int SEE_VALUE[7] = {100, 414, 414, 621, 1005, 30000, 0};
+const int SEE_VALUE[7] = {100, 422, 422, 642, 1015, 30000, 0};
 
 // Static exchange evaluation using The Swap Algorithm - https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm
 inline int SEE(Board* board, Move move, int threshold) {

--- a/src/see.c
+++ b/src/see.c
@@ -24,7 +24,7 @@
 #include "types.h"
 #include "util.h"
 
-const int SEE_VALUE[7] = {100, 565, 565, 705, 1000, 30000, 0};
+const int SEE_VALUE[7] = {100, 477, 477, 589, 928, 30000, 0};
 
 // Static exchange evaluation using The Swap Algorithm - https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm
 inline int SEE(Board* board, Move move, int threshold) {

--- a/src/see.c
+++ b/src/see.c
@@ -24,7 +24,7 @@
 #include "types.h"
 #include "util.h"
 
-const int SEE_VALUE[7] = {100, 400, 400, 650, 850, 30000, 0};
+const int SEE_VALUE[7] = {100, 425, 425, 645, 870, 30000, 0};
 
 // Static exchange evaluation using The Swap Algorithm - https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm
 inline int SEE(Board* board, Move move, int threshold) {

--- a/src/see.c
+++ b/src/see.c
@@ -24,7 +24,7 @@
 #include "types.h"
 #include "util.h"
 
-const int SEE_VALUE[7] = {100, 477, 477, 589, 928, 30000, 0};
+const int SEE_VALUE[7] = {100, 400, 400, 650, 850, 30000, 0};
 
 // Static exchange evaluation using The Swap Algorithm - https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm
 inline int SEE(Board* board, Move move, int threshold) {


### PR DESCRIPTION
Three parameters (minors, rook, queen) tuned with CTT for 919 epochs. Initial 2xx epochs were just for sampling using the `ts` acquisition function, remaining epochs used `pvrs` to focus the result.

Bench: 3843390

**STC**
```
ELO   | 7.92 +- 4.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 9128 W: 2334 L: 2126 D: 4668
```
**LTC**
```
ELO   | 2.97 +- 2.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 23760 W: 5414 L: 5211 D: 13135
```