### PR TITLE
Properly identify fifty move rule

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -702,6 +702,8 @@ inline int IsFiftyMoveRule(Board* board) {
 
       return moves->count > 0;
     }
+
+    return 1;
   }
 
   return 0;


### PR DESCRIPTION
[This commit](https://github.com/jhonnold/berserk/commit/574f4c555843ffff9b5af73efc65f7b74c318731) did not properly replicate standard fifty move rule logic when fixing the checkmate issue. This is a simple fix.

Bench: 3843390

**STC**
```
ELO   | 2.50 +- 4.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 10832 W: 2635 L: 2557 D: 5640
```

**LTC**
```
None
```