### PR TITLE
Reduce hash move when there is a potential multi-cut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -534,6 +534,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         extension = 1 + (!isPV && score < sBeta - 50);
       else if (sBeta >= beta)
         return sBeta;
+      else if (ttScore >= beta)
+        extension = -1;
     }
 
     // history extension - if the tt move has a really good history score, extend.


### PR DESCRIPTION
Bench: 3904316

Idea originating from Vizviz concept to trigger multi-cut more often using a reduced search. This has since been modified to be a negative extension.

```
ELO   | 5.08 +- 3.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 16128 W: 3987 L: 3751 D: 8390
```