### PR TITLE
Prefetch before NN Accumulator updates

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -505,6 +505,9 @@ void MakeMoveUpdate(Move move, Board* board, int update) {
   board->stm ^= 1;
   board->zobrist ^= ZOBRIST_SIDE_KEY;
 
+  // Prefetch the hash entry for this board position
+  TTPrefetch(board->zobrist);
+
   // special pieces must be loaded after the stm has changed
   // this is because the new stm to move will be the one in check
   SetSpecialPieces(board);
@@ -523,9 +526,6 @@ void MakeMoveUpdate(Move move, Board* board, int update) {
       ApplyUpdates(board, BLACK, bUpdates);
     }
   }
-
-  // Prefetch the hash entry for this board position
-  TTPrefetch(board->zobrist);
 }
 
 void UndoMove(Move move, Board* board) {


### PR DESCRIPTION
Bench: 3904316

Prefetch is most helpful when executed as soon as possible. In the case of making a move, this is right after the final zobrist is calculated. As this is purely a speed-up patch, I did not run an LTC.

**STC**
```
ELO   | 9.37 +- 5.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 7416 W: 1853 L: 1653 D: 3910
```


