### PR TITLE
Remove TT Exact from QSearch

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -680,7 +680,6 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
   }
 
   Move bestMove = NULL_MOVE;
-  int origAlpha = alpha;
   int bestScore = -CHECKMATE + data->ply;
 
   // pull cached eval if it exists
@@ -728,7 +727,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
     }
   }
 
-  int TTFlag = bestScore >= beta ? TT_LOWER : bestScore <= origAlpha ? TT_UPPER : TT_EXACT;
+  int TTFlag = bestScore >= beta ? TT_LOWER : TT_UPPER;
   TTPut(board->zobrist, 0, bestScore, TTFlag, bestMove, data->ply, data->evals[data->ply]);
 
   return bestScore;


### PR DESCRIPTION
Bench: 3260448

ELO   | 0.04 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 41704 W: 9861 L: 9856 D: 21987