### PR TITLE
Continuation History Fix

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -90,10 +90,10 @@ int GetQuietHistory(SearchData* data, Move move, int stm, BitBoard threats) {
   int history = HH(stm, move, threats);
 
   Move parent = data->moves[data->ply - 1];
-  history += CH(parent, move);
+  if (parent) history += CH(parent, move);
 
   Move grandParent = data->moves[data->ply - 2];
-  history += FH(grandParent, move);
+  if (grandParent) history += FH(grandParent, move);
 
   return history;
 }


### PR DESCRIPTION
Bench: 3614027

It was originally assumed that even if a parent move didn’t exist, it wouldn’t have an impact on the resulting history. This is not the case as it is represented the same as a pawn promotion to a8. This is a small fix that checks the move exists prior to pulling from history.

Only ran STC as this is mostly a slow down concern.

ELO   | 1.88 +- 3.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 15728 W: 3785 L: 3700 D: 8243
