### PR TITLE
Increase late move reductions for quiets when TT move is a capture

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -49,7 +49,7 @@ extern volatile int PONDERING;
 
 void InitPruningAndReductionTables() {
   for (int depth = 1; depth < MAX_SEARCH_PLY; depth++)
-    for (int moves = 1; moves < 64; moves++) LMR[depth][moves] = 0.1 + log(depth) * log(moves) / 2;
+    for (int moves = 1; moves < 64; moves++) LMR[depth][moves] = log(depth) * log(moves) / 2 - 0.2;
 
   LMR[0][0] = LMR[0][1] = LMR[1][0] = 0;
 
@@ -573,6 +573,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         if (!improving) R++;
 
         if (killerOrCounter) R -= 2;
+
+        if (IsCap(hashMove)) R++;
 
         // move GAVE check
         if (board->checkers) R--;


### PR DESCRIPTION
Bench: 3970483

**STC**
```
ELO   | 2.53 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 32784 W: 7951 L: 7712 D: 17121
```

**LTC**
```
ELO   | 2.37 +- 1.88 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 58480 W: 13250 L: 12851 D: 32379
```