### PR TITLE
Train a new network with Koivisto's Trainer

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,8 +4,8 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 9-dev
-MAIN_NETWORK = networks/berserk-ce3e68d5d598.nn
+VERSION  = 20220524
+MAIN_NETWORK = networks/berserk-e92684e9b4b6.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG
 

--- a/src/nn.c
+++ b/src/nn.c
@@ -188,9 +188,7 @@ void ApplyUpdates(Board* board, int stm, NNUpdate* updates) {
     for (int j = 0; j < N_HIDDEN; j++) output[j] += INPUT_WEIGHTS[updates->additions[i] * N_HIDDEN + j];
 }
 
-const size_t NETWORK_SIZE = sizeof(char) * 4 // BRKR
-  + sizeof(uint64_t) // Hash
-  + sizeof(float) * N_FEATURES * N_HIDDEN // input weights
+const size_t NETWORK_SIZE = sizeof(float) * N_FEATURES * N_HIDDEN // input weights
   + sizeof(float) * N_HIDDEN // input biases
   + sizeof(float) * 2 * N_HIDDEN // output weights
   + sizeof(float); // output bias
@@ -198,12 +196,7 @@ const size_t NETWORK_SIZE = sizeof(char) * 4 // BRKR
 INLINE int32_t LoadWeight(float v, int precision) { return round(v * precision); }
 
 INLINE void CopyData(const unsigned char* in) {
-  if (in[0] != 'B' || in[1] != 'R' || in[2] != 'K' || in[3] != 'R')
-    printf("info string Berserk is not using a standard net, use with caution!\n");
-
-  NN_HASH = *((uint64_t*)(in + 4));
-
-  float* data = (float*)in + 3;  // Skip the 4 byte magic and 8 byte hash
+  float* data = (float*)in;
 
   for (int j = 0; j < N_FEATURES * N_HIDDEN; j++) INPUT_WEIGHTS[j] = LoadWeight(*data++, QUANTIZATION_PRECISION_IN);
 


### PR DESCRIPTION
Bench: 3805240

This network is most likely neutral with Berserk's current network. However, this set's a new baseline for Berserk to improve from utilizing Koivisto's Trainer.

**STC**
```
ELO   | 1.56 +- 3.39 (95%)
CONF  | 8.0+0.08s Threads=1 Hash=8MB
GAMES | N: 20008 W: 5030 L: 4940 D: 10038
```