### PR TITLE
Load Pre Quantized Networks

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -5,7 +5,7 @@ EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
 VERSION  = 20220525
-MAIN_NETWORK = networks/berserk-4bd9bb195b98.nn
+MAIN_NETWORK = networks/berserk-e8e8f3501594.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG
 


### PR DESCRIPTION
Bench: 3701737

Non Functional apart from one tweak on how the output bias is quantized. This change is to keep the binary and networks small.

**STC**
```
ELO   | 0.35 +- 3.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 21896 W: 5170 L: 5148 D: 11578
```