### PR TITLE
Don't rely on game move number of Board History

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 20220525
+VERSION  = 20220529
 MAIN_NETWORK = networks/berserk-e8e8f3501594.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/types.h
+++ b/src/types.h
@@ -22,7 +22,6 @@
 
 #define MAX_SEARCH_PLY 100
 #define MAX_MOVES 128
-#define MAX_GAME_PLY 1024
 
 #define N_FEATURES (8 * 12 * 64)
 #define N_HIDDEN 512
@@ -56,7 +55,8 @@ typedef struct {
   int stm, xstm;  // stm to move
   int epSquare;   // en passant square (a8 or 0 is not valid so that marks no active ep)
   int castling;   // castling mask e.g. 1111 = KQkq, 1001 = Kq
-  int moveNo;     // current game move number TODO: Is this still used?
+  int histPly;
+  int moveNo;    
   int halfMove;   // half move count for 50 move rule
   int ply;
   int phase;
@@ -76,13 +76,13 @@ typedef struct {
   int castlingRights[64];
 
   // data that is hard to track, so it is "remembered" when search undoes moves
-  int castlingHistory[MAX_GAME_PLY];
-  int epSquareHistory[MAX_GAME_PLY];
-  int captureHistory[MAX_GAME_PLY];
-  int halfMoveHistory[MAX_GAME_PLY];
-  uint64_t zobristHistory[MAX_GAME_PLY];
-  BitBoard checkersHistory[MAX_GAME_PLY];
-  BitBoard pinnedHistory[MAX_GAME_PLY];
+  int castlingHistory[MAX_SEARCH_PLY + 100];
+  int epSquareHistory[MAX_SEARCH_PLY + 100];
+  int captureHistory[MAX_SEARCH_PLY + 100];
+  int halfMoveHistory[MAX_SEARCH_PLY + 100];
+  uint64_t zobristHistory[MAX_SEARCH_PLY + 100];
+  BitBoard checkersHistory[MAX_SEARCH_PLY + 100];
+  BitBoard pinnedHistory[MAX_SEARCH_PLY + 100];
 } Board;
 
 typedef struct {

--- a/src/uci.c
+++ b/src/uci.c
@@ -201,6 +201,9 @@ void ParsePosition(char* in, Board* board) {
     if (!enteredMove) break;
 
     MakeMoveUpdate(enteredMove, board, 0);
+
+    if (board->halfMove == 0)
+      board->histPly = 0;
   }
 }
 


### PR DESCRIPTION
Bench: 3701737

This change is mostly to address the issue of game length being capped at 1024 ply (in reality about ~462 moves). Games that lasted longer than this would result in Berserk crashing. Now, board history is only saved as far back as the 50mr when search begins (it will save the entire history during search). Berserk now also properly keeps track of move number since it's no longer dependent on it within search.

Ran a single STC regression test.

**STC**
```
ELO   | 1.89 +- 4.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 12664 W: 3031 L: 2962 D: 6671
```