### PR TITLE
CounterHistory Fix

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -102,7 +102,7 @@ int GetCounterHistory(SearchData* data, Move move) {
   if (IsTactical(move)) return 0;
 
   Move parent = data->moves[data->ply - 1];
-  return CH(parent, move);
+  return parent ? CH(parent, move) : 0;
 }
 
 int GetTacticalHistory(SearchData* data, Board* board, Move m) {

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 20220531
+VERSION  = 20220601
 MAIN_NETWORK = networks/berserk-e8e8f3501594.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 3551146

A small bug fix that should prevent the pulling of incorrect counter history values.

**STC**
```
ELO   | 1.13 +- 3.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 15976 W: 3776 L: 3724 D: 8476
```

**LTC**
_As this is simply a small regression check, no LTC was run_