### PR TITLE
Limit Double Extensions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -398,6 +398,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   data->skipMove[data->ply + 1] = NULL_MOVE;
   data->killers[data->ply + 1][0] = NULL_MOVE;
   data->killers[data->ply + 1][1] = NULL_MOVE;
+  data->de[data->ply] = isRoot ? 0 : data->de[data->ply - 1];
 
   Threat oppThreat;
   Threats(&oppThreat, board, board->xstm);
@@ -531,9 +532,14 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       data->skipMove[data->ply] = NULL_MOVE;
 
       // no score failed above sBeta, so this is singular
-      if (score < sBeta)
-        extension = 1 + (!isPV && score < sBeta - 50);
-      else if (sBeta >= beta)
+      if (score < sBeta) {
+        if (!isPV && score < sBeta - 50 && data->de[data->ply - 1] <= 6) {
+          extension = 2;
+          data->de[data->ply] = data->de[data->ply - 1] + 1;
+        } else {
+          extension = 1;
+        }
+      } else if (sBeta >= beta)
         return sBeta;
       else if (ttScore >= beta)
         extension = -1;

--- a/src/thread.c
+++ b/src/thread.c
@@ -64,6 +64,7 @@ void InitPool(Board* board, SearchParams* params, ThreadData* threads, SearchRes
     memset(&threads[i].data.skipMove, 0, sizeof(threads[i].data.skipMove));
     memset(&threads[i].data.evals, 0, sizeof(threads[i].data.evals));
     memset(&threads[i].data.tm, 0, sizeof(threads[i].data.tm));
+    memset(&threads[i].data.de, 0, sizeof(threads[i].data.de));
 
     // set the moves arr as an offset of 2
     memset(&threads[i].data.searchMoves, 0, sizeof(threads[i].data.searchMoves));

--- a/src/types.h
+++ b/src/types.h
@@ -112,6 +112,8 @@ typedef struct {
 
   int contempt[2];
 
+  int de[MAX_SEARCH_PLY]; // double extensions
+
   Move skipMove[MAX_SEARCH_PLY];         // moves to skip during singular search
   int evals[MAX_SEARCH_PLY];             // static evals at ply stack
   Move searchMoves[MAX_SEARCH_PLY + 2];  // moves for ply stack


### PR DESCRIPTION
Bench: 3548864

In order to prevent search explosions, this patch adds limitations on double extensions.

**STC**
```
ELO   | -1.05 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 62432 W: 14521 L: 14709 D: 33202
```

**LTC**
```
ELO   | -0.11 +- 2.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 49296 W: 10931 L: 10946 D: 27419
```