### PR TITLE
No PV TT Cutoff in QSearch + Removal of consecutive fail highs

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -666,6 +666,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
   Board* board = &thread->board;
 
   int mainThread = !thread->idx;
+  int isPV = beta - alpha != 1;
 
   data->nodes++;
 
@@ -681,7 +682,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
   int ttScore = UNKNOWN;
   TTEntry* tt = TTProbe(board->zobrist);
   // TT score pruning - no depth check required since everything in QS is depth 0
-  if (tt) {
+  if (!isPV && tt) {
     ttScore = TTScore(tt, data->ply);
 
     if (ttScore != UNKNOWN && ((tt->flags & TT_EXACT) || ((tt->flags & TT_LOWER) && ttScore >= beta) ||

--- a/src/search.c
+++ b/src/search.c
@@ -147,7 +147,6 @@ void* Search(void* arg) {
 
   // set a hot exit point for this thread
   if (!setjmp(thread->exit)) {
-    int cfh = 0;
     int searchStability = 0;
 
     // Iterative deepening
@@ -188,20 +187,15 @@ void* Search(void* arg) {
             alpha = max(alpha - delta, -CHECKMATE);
 
             searchDepth = depth;
-            cfh = 0;
           } else if (score >= beta) {
             beta = min(beta + delta, CHECKMATE);
 
-            if (abs(score) < TB_WIN_BOUND) {
-              cfh += 2;
-              searchDepth -= cfh;
-              searchDepth = max(1, searchDepth);
-            }
+            if (abs(score) < TB_WIN_BOUND)
+              searchDepth--;
           } else {
             thread->scores[thread->multiPV] = score;
             thread->bestMoves[thread->multiPV] = pv->moves[0];
 
-            cfh = 0;
             break;
           }
 


### PR DESCRIPTION
Bench: 4387316

Removing PV TT cutoffs in QSearch as it results in a bugged eval when opponent has few moves. This was identified in the extreme with endgame specific evals. Standard removal results in ~10 Elo lost, which is the result of consecutive fail highs, which are also simplified out in this patch.

**STC**
```
ELO   | -3.79 +- 3.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.98 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 23480 W: 5358 L: 5614 D: 12508
```

**LTC**
```
ELO   | 2.83 +- 4.49 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 10056 W: 2243 L: 2161 D: 5652
```