### PR TITLE
Check max time in between iterative depths

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 20220603
+VERSION  = 20220611
 MAIN_NETWORK = networks/berserk-27c2bc72e784.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 4387316

This is really inexpensive, and should prevent timeouts at low time with no increment.

**STC**
```
ELO   | -0.61 +- 3.41 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-10.00, 0.00]
GAMES | N: 11352 W: 1610 L: 1630 D: 8112
```