### PR TITLE
Include to square threatened in Main History

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -20,7 +20,7 @@
 #include "bits.h"
 #include "types.h"
 
-#define HH(stm, m, threats) (data->hh[stm][!getBit(threats, From(m))][FromTo(m)])
+#define HH(stm, m, threats) (data->hh[stm][!getBit(threats, From(m))][!getBit(threats, To(m))][FromTo(m)])
 #define CH(p, m) (data->ch[Moving(p)][To(p)][Moving(m)][To(m)])
 #define TH(p, e, c) (data->th[p][e][c])
 

--- a/src/types.h
+++ b/src/types.h
@@ -21,7 +21,6 @@
 #include <limits.h>
 #include <setjmp.h>
 
-
 #define MAX_SEARCH_PLY (INT8_MAX + 1)
 #define MAX_MOVES 128
 
@@ -122,7 +121,7 @@ typedef struct {
 
   Move killers[MAX_SEARCH_PLY][2];  // killer moves, 2 per ply
   Move counters[64 * 64];           // counter move butterfly table
-  int hh[2][2][64 * 64];            // history heuristic butterfly table (stm / threatened)
+  int hh[2][2][2][64 * 64];         // history heuristic butterfly table (stm / threatened)
   int ch[12][64][12][64];           // continuation move history table
 
   int th[6][64][6];  // tactical (capture) history


### PR DESCRIPTION
Bench: 4725288

Index the main history table on whether or not the moving piece is threatened and if it's ending square is also threatened

**STC**
```
ELO   | 8.82 +- 5.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 5912 W: 1408 L: 1258 D: 3246
```

**LTC**
```
ELO   | 4.72 +- 3.44 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 16784 W: 3711 L: 3483 D: 9590
```