### PR TITLE
Smaller margin to trigger double extensions

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 20220612
+VERSION  = 20220613
 MAIN_NETWORK = networks/berserk-27c2bc72e784.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -533,7 +533,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       // no score failed above sBeta, so this is singular
       if (score < sBeta) {
-        if (!isPV && score < sBeta - 25 && data->de[data->ply - 1] <= 6) {
+        if (!isPV && score < sBeta - 35 && data->de[data->ply - 1] <= 6) {
           extension = 2;
           data->de[data->ply] = data->de[data->ply - 1] + 1;
         } else {

--- a/src/search.c
+++ b/src/search.c
@@ -533,7 +533,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       // no score failed above sBeta, so this is singular
       if (score < sBeta) {
-        if (!isPV && score < sBeta - 50 && data->de[data->ply - 1] <= 6) {
+        if (!isPV && score < sBeta - 25 && data->de[data->ply - 1] <= 6) {
           extension = 2;
           data->de[data->ply] = data->de[data->ply - 1] + 1;
         } else {


### PR DESCRIPTION
Bench: 4835487

**STC**
```
ELO   | 3.07 +- 3.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 24080 W: 5897 L: 5684 D: 12499
```

**LTC**
```
ELO   | 2.38 +- 1.89 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 56288 W: 12379 L: 11993 D: 31916
```