### PR TITLE
Small Endgame Eval Patch

### DIFF
--- a/src/bits.h
+++ b/src/bits.h
@@ -65,16 +65,16 @@
 #define ShiftNW(bb) (((bb) & ~A_FILE) >> 9)
 #define ShiftSE(bb) (((bb) & ~H_FILE) << 9)
 
-INLINE BitBoard ShiftPawnDir(BitBoard bb, const int c) {
-  return c == WHITE ? ShiftN(bb) : ShiftS(bb);
-}
+INLINE BitBoard ShiftPawnDir(BitBoard bb, const int c) { return c == WHITE ? ShiftN(bb) : ShiftS(bb); }
 
-INLINE BitBoard ShiftPawnCapW(BitBoard bb, const int c) {
-  return c == WHITE ? ShiftNW(bb) : ShiftSW(bb);
-}
+INLINE BitBoard ShiftPawnCapW(BitBoard bb, const int c) { return c == WHITE ? ShiftNW(bb) : ShiftSW(bb); }
 
-INLINE BitBoard ShiftPawnCapE(BitBoard bb, const int c) {
-  return c == WHITE ? ShiftNE(bb) : ShiftSE(bb);
+INLINE BitBoard ShiftPawnCapE(BitBoard bb, const int c) { return c == WHITE ? ShiftNE(bb) : ShiftSE(bb); }
+
+INLINE uint8_t PawnFiles(BitBoard pawns) {
+  pawns |= (pawns >> 8);
+  pawns |= (pawns >> 16);
+  return (uint8_t)((pawns | (pawns >> 32)) & 0xFF);
 }
 
 INLINE int popAndGetLsb(BitBoard* bb) {

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 9
+VERSION  = 20220618
 MAIN_NETWORK = networks/berserk-27c2bc72e784.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -438,7 +438,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       UndoNullMove(board);
       data->ply--;
 
-      if (score >= beta) return score < TB_WIN_BOUND ? score : beta;
+      if (score >= beta) return score < WINNING_ENDGAME ? score : beta;
     }
 
     // Prob cut


### PR DESCRIPTION
Bench: 4888890

Small endgame patch to fix stacked rook pawns in special endgames.

**STC**
```
ELO   | -0.26 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 30832 W: 7017 L: 7040 D: 16775
```