### PR TITLE
QSearch TT Exact Results

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -684,8 +684,8 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
   if (!isPV && tt) {
     ttScore = TTScore(tt, data->ply);
 
-    if (ttScore != UNKNOWN &&
-        (((tt->flags & TT_LOWER) && ttScore >= beta) || ((tt->flags & TT_UPPER) && ttScore <= alpha)))
+    if (ttScore != UNKNOWN && ((tt->flags & TT_EXACT) || ((tt->flags & TT_LOWER) && ttScore >= beta) ||
+                               ((tt->flags & TT_UPPER) && ttScore <= alpha)))
       return ttScore;
   }
 


### PR DESCRIPTION
Bench: 4596215

This was accidentally removed when testing EG specific evals and missed adding back

**STC**
```
ELO   | -0.38 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 33456 W: 7626 L: 7663 D: 18167
```