### PR TITLE
Disable late move pruning at root + improve ordering

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -494,7 +494,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     int counterHistory = GetCounterHistory(data, move);
 
     if (bestScore > -MATE_BOUND) {
-      if (legalMoves >= LMP[improving][depth]) skipQuiets = 1;
+      if (!isRoot && legalMoves >= LMP[improving][depth]) skipQuiets = 1;
 
       if (!tactical) {
         if (depth < 3 && !killerOrCounter && (history < -4096 * depth || counterHistory < -2048 * depth)) continue;

--- a/src/thread.c
+++ b/src/thread.c
@@ -67,7 +67,6 @@ void InitPool(Board* board, SearchParams* params, ThreadData* threads, SearchRes
     memset(&threads[i].data.de, 0, sizeof(threads[i].data.de));
 
     // set the moves arr as an offset of 2
-    memset(&threads[i].data.searchMoves, 0, sizeof(threads[i].data.searchMoves));
     threads[i].data.moves = &threads[i].data.searchMoves[2];
 
     memset(&threads[i].scores, 0, sizeof(threads[i].scores));
@@ -93,7 +92,7 @@ void ResetThreadPool(ThreadData* threads) {
     // empty ALL data
     memset(&threads[i].data.skipMove, 0, sizeof(threads[i].data.skipMove));
     memset(&threads[i].data.evals, 0, sizeof(threads[i].data.evals));
-    memset(&threads[i].data.moves, 0, sizeof(threads[i].data.moves));
+    memset(&threads[i].data.searchMoves, 0, sizeof(threads[i].data.searchMoves));
     memset(&threads[i].data.killers, 0, sizeof(threads[i].data.killers));
     memset(&threads[i].data.counters, 0, sizeof(threads[i].data.counters));
     memset(&threads[i].data.hh, 0, sizeof(threads[i].data.hh));

--- a/src/uci.h
+++ b/src/uci.h
@@ -25,7 +25,7 @@ extern int CONTEMPT;
 void RootMoves(SimpleMoveList* moves, Board* board);
 
 void ParseGo(char* in, SearchParams* params, Board* board, ThreadData* threads);
-void ParsePosition(char* in, Board* board);
+void ParsePosition(char* in, Board* board, ThreadData* threads);
 void PrintUCIOptions();
 
 int ReadLine(char* in);


### PR DESCRIPTION
Bench: 4668056

LMP at root has shown to be relatively neutral. Combine this with improved ordering by caching the two previous moves and it turns into a small improvement at STC. Most likely this is 0 Elo at LTC, but merging to improve overall STC performance.

**STC**
ELO   | 2.56 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 31000 W: 7263 L: 7035 D: 16702