### PR TITLE
Bench: 5159214

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -31,11 +31,11 @@ void AddKillerMove(SearchData* data, Move move) {
 
 void AddCounterMove(SearchData* data, Move move, Move parent) { data->counters[FromTo(parent)] = move; }
 
-void AddHistoryHeuristic(int* entry, int inc) { *entry += 64 * inc - *entry * abs(inc) / 1024; }
+void AddHistoryHeuristic(int* entry, int inc) { *entry += inc - *entry * abs(inc) / 65536; }
 
 void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, int stm, Move quiets[], int nQ,
                      Move tacticals[], int nT, BitBoard threats) {
-  int inc = min(depth * depth, 576);
+  int inc = min(7584, 16 * depth * depth + 480 * depth - 480);
 
   Move parent = data->moves[data->ply - 1];
   Move grandParent = data->moves[data->ply - 2];


### PR DESCRIPTION
Bench: 5159214

Adjust history formula. This tweak results in lower values at higher depth and greater values at lower depth. Since this formula will effectively trigger history impacts at lower depths faster, that is why I suspect it does so well at LTC relative to STC. I do not suspect this will lose any Elo at VLTC.

**STC**
```
ELO   | 4.54 +- 4.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 13464 W: 3228 L: 3052 D: 7184
```

**LTC**
```
ELO   | 2.18 +- 1.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 69784 W: 15366 L: 14929 D: 39489
```