### PR TITLE
Corrent singular search results

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -642,7 +642,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   }
 
   // Checkmate detection using movecount
-  if (!legalMoves) return board->checkers ? -CHECKMATE + data->ply : 0;
+  if (!legalMoves) return skipMove ? alpha : board->checkers ? -CHECKMATE + data->ply : 0;
 
   // don't let our score inflate too high (tb)
   bestScore = min(bestScore, maxScore);


### PR DESCRIPTION
Bench: 4976609

Correct the checkmate/stalemate logic to return alpha when there are no legal moves in a singular search. We know this is not true, we've just excluded it.

**STC**
```
ELO   | -0.88 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 52136 W: 11891 L: 12023 D: 28222
```