### PR TITLE
Reverse Futility Pruning Margin Tweak

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 20220620
+VERSION  = 20220629
 MAIN_NETWORK = networks/berserk-11a8ee076cec.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -412,7 +412,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
-    if (depth <= 6 && !skipMove && eval - 50 * (depth - (improving && !oppThreat.pcs)) > beta && eval < WINNING_ENDGAME)
+    if (depth <= 6 && !skipMove && eval - 75 * (depth - (improving && !oppThreat.pcs)) > beta && eval < WINNING_ENDGAME)
       return eval;
 
     // Razoring


### PR DESCRIPTION
Bench: 5842031

Margin Tweak

**STC**
```
ELO   | 2.03 +- 2.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 48872 W: 11552 L: 11267 D: 26053
```

**LTC**
```
ELO   | 3.86 +- 2.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 23144 W: 5197 L: 4940 D: 13007
```