### PR TITLE
Remove Counter History Pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -491,14 +491,11 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     int tactical = IsTactical(move);
     int killerOrCounter = move == moves.killer1 || move == moves.killer2 || move == moves.counter;
     int history = GetQuietHistory(data, move, board->stm, oppThreat.sqs);
-    int counterHistory = GetCounterHistory(data, move);
 
     if (bestScore > -MATE_BOUND) {
       if (!isRoot && legalMoves >= LMP[improving][depth]) skipQuiets = 1;
 
       if (!tactical) {
-        if (depth < 3 && !killerOrCounter && counterHistory < -2048 * depth) continue;
-
         if (depth < 9 && eval + 100 + 50 * depth + history / 512 <= alpha) skipQuiets = 1;
 
         if (!SEE(board, move, STATIC_PRUNE[0][depth])) continue;


### PR DESCRIPTION
Bench: 6151201

**STC**
```
ELO   | 1.13 +- 3.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 15952 W: 3772 L: 3720 D: 8460
```

**LTC**
```
ELO   | 0.71 +- 2.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 26304 W: 5844 L: 5790 D: 14670
```