### PR TITLE
1024 Hidden Neurons

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,8 +4,8 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 20220701
-MAIN_NETWORK = networks/berserk-11a8ee076cec.nn
+VERSION  = 20220718
+MAIN_NETWORK = networks/berserk-70370ef71611.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG
 

--- a/src/types.h
+++ b/src/types.h
@@ -27,7 +27,7 @@
 #define N_KING_BUCKETS 8
 
 #define N_FEATURES (8 * 12 * 64)
-#define N_HIDDEN 512
+#define N_HIDDEN 1024
 #define N_OUTPUT 1
 
 #if defined(__AVX512F__)


### PR DESCRIPTION
Bench: 4894589

Double the size of the hidden layer within Berserk's network. This results in a major slowdown that results in a regression at STC. However, this network scales exceptionally well at LTC.

**STC**
```
ELO   | -11.15 +- 3.94 (95%)
CONF  | 8.0+0.08s Threads=1 Hash=8MB
GAMES | N: 14872 W: 3462 L: 3939 D: 7471
```

**LTC**
```
ELO   | 7.02 +- 4.22 (95%)
CONF  | 120.0+1.00s Threads=1 Hash=64MB
GAMES | N: 11728 W: 2763 L: 2526 D: 6439
```