### PR TITLE
Remove root delta in LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -567,15 +567,13 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         // increase reduction on non-pv
         if (!isPV) R++;
 
-        // vizviz root delta idea in LMR
-        // if we've found a reasonable move already, reduce others more
-        if (isPV && (beta - alpha) * 2 < data->window) R++;
-
         // increase reduction if our eval is declining
         if (!improving) R++;
 
+        // reduce these special quiets less
         if (killerOrCounter) R -= 2;
 
+        // less likely a non-capture is best
         if (IsCap(hashMove)) R++;
 
         // move GAVE check


### PR DESCRIPTION
Bench: 5642107

**STC**
```
ELO   | -0.74 +- 2.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 44224 W: 10414 L: 10508 D: 23302
```

**LTC**
```
ELO   | 6.46 +- 5.77 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 6128 W: 1408 L: 1294 D: 3426
```