### PR TITLE
EP square only when viable

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -412,8 +412,12 @@ void MakeMoveUpdate(Move move, Board* board, int update) {
   }
 
   if (dub) {
-    board->epSquare = to - PawnDir(board->stm);
-    board->zobrist ^= ZOBRIST_EP_KEYS[board->epSquare];
+    int epSquare = to - PawnDir(board->stm);
+    
+    if (GetPawnAttacks(epSquare, board->stm) & PieceBB(PAWN, board->xstm)) {
+      board->epSquare = epSquare;
+      board->zobrist ^= ZOBRIST_EP_KEYS[board->epSquare];
+    }
   }
 
   if (castle) {

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 20220721
+VERSION  = 20220725
 MAIN_NETWORK = networks/berserk-70370ef71611.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 5427009

Only calculate the EP square when an enemy pawn is in place to capture it. This will help will three move repetitions where the first position is after a double pawn push.

**STC**
```
ELO   | 2.56 +- 4.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 10728 W: 2580 L: 2501 D: 5647
```