### PR TITLE
Return to 512 Hidden Neurons

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,8 +4,8 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c noobprobe/*.c
 CC       = gcc
-VERSION  = 20220725
-MAIN_NETWORK = networks/berserk-70370ef71611.nn
+VERSION  = 20220818
+MAIN_NETWORK = networks/berserk-11a8ee076cec.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG
 

--- a/src/types.h
+++ b/src/types.h
@@ -27,7 +27,7 @@
 #define N_KING_BUCKETS 8
 
 #define N_FEATURES (8 * 12 * 64)
-#define N_HIDDEN 1024
+#define N_HIDDEN 512
 #define N_OUTPUT 1
 
 #if defined(__AVX512F__)


### PR DESCRIPTION
Bench: 5082933

Returning to 512 hidden neurons as it seems the scaling of the 1024 hidden layer network do not outweigh the negatives.

ELO   | 1.32 +- 2.13 (95%)
CONF  | 40.0+0.40s Threads=1 Hash=64MB
GAMES | N: 20000 W: 1998 L: 1922 D: 16080