### PR TITLE
Separate promotions in tactical history on captures

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -53,7 +53,7 @@ void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, i
   } else {
     int piece = PieceType(Moving(bestMove));
     int to = To(bestMove);
-    int captured = (IsEP(bestMove) || Promo(bestMove)) ? PAWN : PieceType(board->squares[to]);
+    int captured = IsEP(bestMove) ? PAWN : PieceType(board->squares[to]);
 
     AddHistoryHeuristic(&TH(piece, to, captured), inc);
   }
@@ -77,7 +77,7 @@ void UpdateHistories(Board* board, SearchData* data, Move bestMove, int depth, i
     if (m != bestMove) {
       int piece = PieceType(Moving(m));
       int to = To(m);
-      int captured = (IsEP(m) || Promo(m)) ? PAWN : PieceType(board->squares[to]);
+      int captured = IsEP(m) ? PAWN : PieceType(board->squares[to]);
 
       AddHistoryHeuristic(&TH(piece, to, captured), -inc);
     }
@@ -108,7 +108,7 @@ int GetCounterHistory(SearchData* data, Move move) {
 int GetTacticalHistory(SearchData* data, Board* board, Move m) {
   int piece = PieceType(Moving(m));
   int to = To(m);
-  int captured = (IsEP(m) || Promo(m)) ? PAWN : PieceType(board->squares[to]);
+  int captured = IsEP(m) ? PAWN : PieceType(board->squares[to]);
 
   return TH(piece, to, captured);
 }

--- a/src/types.h
+++ b/src/types.h
@@ -137,7 +137,7 @@ typedef struct {
   int hh[2][2][2][64 * 64];         // history heuristic butterfly table (stm / threatened)
   int ch[12][64][12][64];           // continuation move history table
 
-  int th[6][64][6];  // tactical (capture) history
+  int th[6][64][7];  // tactical (capture) history
 
   int64_t tm[64 * 64];
 } SearchData;


### PR DESCRIPTION
Bench: 5480015

Separate promotion captures from promotions in tactical history.

**STC**
```
ELO   | 3.08 +- 3.05 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 23032 W: 5439 L: 5235 D: 12358
```

**LTC**
```
ELO   | 1.34 +- 1.92 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | -0.10 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 55176 W: 12288 L: 12075 D: 30813
```