### PR TITLE
Accumulator update via Move

### DIFF
--- a/src/nn.h
+++ b/src/nn.h
@@ -34,14 +34,7 @@ void StoreAccumulatorKingState(Accumulator accumulator, Board* board, const int 
 void RefreshAccumulator(Accumulator accumulator, Board* board, const int perspective);
 void ResetAccumulator(Accumulator output, Board* board, const int perspective);
 
-void ApplyUpdates(Board* board, int stm, NNUpdate* updates);
-
-INLINE void AddAddition(int f, NNUpdate* updates) {
-  updates->additions[updates->na++] = f;
-}
-INLINE void AddRemoval(int f, NNUpdate* updates) {
-  updates->removals[updates->nr++] = f;
-}
+void ApplyUpdates(Board* board, Move move, int captured, const int view);
 
 void LoadDefaultNN();
 int LoadNetwork(char* path);

--- a/src/types.h
+++ b/src/types.h
@@ -44,12 +44,6 @@ typedef uint32_t Move;
 
 enum { SUB = 0, ADD = 1 };
 
-typedef struct {
-  int na, nr;
-  int additions[2];
-  int removals[2];
-} NNUpdate;
-
 typedef int16_t Accumulator[N_HIDDEN] __attribute__((aligned(ALIGN_ON)));
 
 typedef struct {


### PR DESCRIPTION
Bench: 5480015

Determine diff for Accumulators via the move. Functionally the same.

**STC**
```
ELO   | 0.85 +- 2.97 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 24224 W: 5622 L: 5563 D: 13039
```