### PR TITLE
Reduce more in NMP when there are no opponent threats

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -422,7 +422,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     if (depth >= 3 && data->moves[data->ply - 1] != NULL_MOVE && !skipMove && eval >= beta &&
         // weiss conditional
         HasNonPawn(board) > (depth > 12)) {
-      int R = 4 + depth / 6 + min((eval - beta) / 256, 3);
+      int R = 3 + depth / 6 + min((eval - beta) / 256, 3) + !oppThreat.pcs;
       R     = min(depth, R); // don't go too low
 
       data->moves[data->ply++] = NULL_MOVE;

--- a/src/search.c
+++ b/src/search.c
@@ -422,7 +422,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     if (depth >= 3 && data->moves[data->ply - 1] != NULL_MOVE && !skipMove && eval >= beta &&
         // weiss conditional
         HasNonPawn(board) > (depth > 12)) {
-      int R = 3 + depth / 6 + min((eval - beta) / 256, 3) + !oppThreat.pcs;
+      int R = 4 + depth / 6 + min((eval - beta) / 256, 3) + !oppThreat.pcs;
       R     = min(depth, R); // don't go too low
 
       data->moves[data->ply++] = NULL_MOVE;


### PR DESCRIPTION
Bench: 5036481

**STC**
```
ELO   | 3.84 +- 3.57 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 16736 W: 3947 L: 3762 D: 9027
```

**LTC**
```
ELO   | 2.52 +- 2.02 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 49456 W: 10927 L: 10568 D: 27961
```