### PR TITLE
Don't reduce more for previous PV moves

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20220905
+VERSION  = 20220912
 MAIN_NETWORK = networks/berserk-11a8ee076cec.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -279,6 +279,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   int maxScore   = CHECKMATE;         // best possible
   int origAlpha  = alpha;             // remember first alpha for tt storage
   int ttScore    = UNKNOWN;
+  int ttPv       = 0;
 
   Move bestMove = NULL_MOVE;
   Move skipMove = data->skipMove[data->ply]; // skip used in SE (concept from SF)
@@ -320,6 +321,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   // we ignore the tt on singular extension searches
   TTEntry* tt = skipMove ? NULL : TTProbe(board->zobrist);
   ttScore     = tt ? TTScore(tt, data->ply) : UNKNOWN;
+  ttPv        = isPV || (tt && (tt->flags & TT_PV));
   hashMove    = isRoot ? thread->pvs[thread->multiPV].moves[0] : tt ? tt->move : NULL_MOVE;
 
   // if the TT has a value that fits our position and has been searched to an equal or greater depth, then we accept
@@ -355,7 +357,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       // if the tablebase gives us what we want, then we accept it's score and return
       if ((flag & TT_EXACT) || ((flag & TT_LOWER) && score >= beta) || ((flag & TT_UPPER) && score <= alpha)) {
-        TTPut(board->zobrist, depth, score, flag, 0, data->ply, 0);
+        TTPut(board->zobrist, depth, score, flag, 0, data->ply, 0, ttPv);
         return score;
       }
 
@@ -383,7 +385,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     eval = data->evals[data->ply];
   }
 
-  if (!tt) TTPut(board->zobrist, INT8_MIN, UNKNOWN, TT_UNKNOWN, NULL_MOVE, data->ply, eval);
+  if (!tt) TTPut(board->zobrist, INT8_MIN, UNKNOWN, TT_UNKNOWN, NULL_MOVE, data->ply, eval, ttPv);
 
   // getting better if eval has gone up
   int improving = !board->checkers && data->ply >= 2 &&
@@ -464,6 +466,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       }
     }
   }
+
+  int failLow = isPV && tt && hashMove && (tt->flags & TT_UPPER) && tt->depth >= depth;
 
   Move quiets[64];
   Move tacticals[64];
@@ -566,6 +570,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // increase reduction if our eval is declining
       if (!improving) R++;
 
+      if (!failLow && ttPv) R--;
+
       // reduce these special quiets less
       if (killerOrCounter) R -= 2;
 
@@ -648,7 +654,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // TT_LOWER = we failed high, TT_UPPER = we didnt raise alpha, TT_EXACT = in
     int TTFlag       = bestScore >= beta ? TT_LOWER : bestScore <= origAlpha ? TT_UPPER : TT_EXACT;
     Move moveToStore = tt && TTFlag == TT_UPPER && (tt->flags & TT_LOWER) ? hashMove : bestMove;
-    TTPut(board->zobrist, depth, bestScore, TTFlag, moveToStore, data->ply, data->evals[data->ply]);
+    TTPut(board->zobrist, depth, bestScore, TTFlag, moveToStore, data->ply, data->evals[data->ply], ttPv);
   }
 
   return bestScore;
@@ -661,6 +667,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
 
   int mainThread = !thread->idx;
   int isPV       = beta - alpha != 1;
+  int ttPv       = 0;
 
   data->nodes++;
 
@@ -675,6 +682,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
   // check the transposition table for previous info
   int ttScore = UNKNOWN;
   TTEntry* tt = TTProbe(board->zobrist);
+  ttPv        = isPV || (tt && (tt->flags & TT_PV));
   // TT score pruning - no depth check required since everything in QS is depth 0
   if (!isPV && tt) {
     ttScore = TTScore(tt, data->ply);
@@ -689,7 +697,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
 
   // pull cached eval if it exists
   int eval = data->evals[data->ply] = board->checkers ? UNKNOWN : (tt ? tt->eval : Evaluate(board, thread));
-  if (!tt) TTPut(board->zobrist, INT8_MIN, UNKNOWN, TT_UNKNOWN, NULL_MOVE, data->ply, eval);
+  if (!tt) TTPut(board->zobrist, INT8_MIN, UNKNOWN, TT_UNKNOWN, NULL_MOVE, data->ply, eval, ttPv);
 
   // can we use an improved evaluation from the tt?
   if (tt && ttScore != UNKNOWN)
@@ -732,7 +740,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread) {
   }
 
   int TTFlag = bestScore >= beta ? TT_LOWER : TT_UPPER;
-  TTPut(board->zobrist, 0, bestScore, TTFlag, bestMove, data->ply, data->evals[data->ply]);
+  TTPut(board->zobrist, 0, bestScore, TTFlag, bestMove, data->ply, data->evals[data->ply], ttPv);
 
   return bestScore;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -467,8 +467,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     }
   }
 
-  int failLow = isPV && tt && hashMove && (tt->flags & TT_UPPER) && tt->depth >= depth;
-
   Move quiets[64];
   Move tacticals[64];
 
@@ -565,12 +563,10 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       R = LMR[min(depth, 63)][min(playedMoves, 63)];
 
       // increase reduction on non-pv
-      if (!isPV) R++;
+      if (!ttPv) R++;
 
       // increase reduction if our eval is declining
       if (!improving) R++;
-
-      if (!failLow && ttPv) R--;
 
       // reduce these special quiets less
       if (killerOrCounter) R -= 2;

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -87,7 +87,7 @@ inline TTEntry* TTProbe(uint64_t hash) {
   return NULL;
 }
 
-inline void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval) {
+inline void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval, int pv) {
   TTBucket* bucket   = &TT.buckets[TT.mask & hash];
   uint32_t shortHash = hash >> 32;
   TTEntry* toReplace = bucket->entries;
@@ -96,6 +96,8 @@ inline void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move
     score += ply;
   else if (score < -MATE_BOUND)
     score -= ply;
+
+  if (pv) flag |= TT_PV;
 
   for (TTEntry* entry = bucket->entries; entry < bucket->entries + BUCKET_SIZE; entry++) {
     if (!entry->hash) {

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -41,7 +41,7 @@ typedef struct {
   uint8_t age;
 } TTTable;
 
-enum { TT_UNKNOWN = 0, TT_LOWER = 1, TT_UPPER = 2, TT_EXACT = 4 };
+enum { TT_UNKNOWN = 0, TT_LOWER = 1, TT_UPPER = 2, TT_EXACT = 4, TT_PV = 8 };
 
 extern TTTable TT;
 
@@ -52,7 +52,7 @@ void TTUpdate();
 void TTPrefetch(uint64_t hash);
 TTEntry* TTProbe(uint64_t hash);
 int TTScore(TTEntry* e, int ply);
-void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval);
+void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval, int pv);
 int TTFull();
 
 #endif


### PR DESCRIPTION
Bench: 5801393

Keep track of moves on the PV and don't increase their reductions even if it's not on a PV node anymore.

**STC**
```
ELO   | 2.97 +- 2.96 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 24320 W: 5712 L: 5504 D: 13104
```

**LTC**
```
ELO   | 3.30 +- 2.61 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 29400 W: 6505 L: 6226 D: 16669
```
