### PR TITLE
Improve NNUE auto-vectorization and update logic

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20220912
+VERSION  = 20220924
 MAIN_NETWORK = networks/berserk-11a8ee076cec.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/nn.c
+++ b/src/nn.c
@@ -172,7 +172,7 @@ void ResetRefreshTable(Board* board) {
     for (int b = 0; b < 2 * N_KING_BUCKETS; b++) {
       AccumulatorKingState* state = &board->refreshTable[c][b];
       memcpy(state->values, INPUT_BIASES, sizeof(int16_t) * N_HIDDEN);
-      for (int pc = WHITE_PAWN; pc < NO_PIECE; pc++) state->pcs[pc] = 0;
+      memset(state->pcs, 0, sizeof(BitBoard) * 12);
     }
   }
 }

--- a/src/nn.h
+++ b/src/nn.h
@@ -18,19 +18,9 @@
 #include "types.h"
 #include "util.h"
 
-extern uint64_t NN_HASH;
-extern const int QUANTIZATION_PRECISION_IN;
-extern const int QUANTIZATION_PRECISION_OUT;
-
-extern int16_t INPUT_WEIGHTS[N_FEATURES * N_HIDDEN];
-extern int16_t INPUT_BIASES[N_HIDDEN];
-extern int16_t OUTPUT_WEIGHTS[2 * N_HIDDEN];
-extern int32_t OUTPUT_BIAS;
-
 int Predict(Board* board);
 int OutputLayer(Accumulator stm, Accumulator xstm);
 void ResetRefreshTable(Board* board);
-void StoreAccumulatorKingState(Accumulator accumulator, Board* board, const int perspective);
 void RefreshAccumulator(Accumulator accumulator, Board* board, const int perspective);
 void ResetAccumulator(Accumulator output, Board* board, const int perspective);
 

--- a/src/types.h
+++ b/src/types.h
@@ -30,13 +30,8 @@
 #define N_HIDDEN   512
 #define N_OUTPUT   1
 
-#if defined(__AVX512F__)
 #define ALIGN_ON 64
-#elif defined(__AVX2__)
-#define ALIGN_ON 32
-#else
-#define ALIGN_ON 16
-#endif
+#define ALIGN __attribute__((aligned(ALIGN_ON)))
 
 typedef int Score;
 typedef uint64_t BitBoard;
@@ -44,14 +39,14 @@ typedef uint32_t Move;
 
 enum { SUB = 0, ADD = 1 };
 
-typedef int16_t Accumulator[N_HIDDEN] __attribute__((aligned(ALIGN_ON)));
+typedef int16_t Accumulator[N_HIDDEN] ALIGN;
 
 typedef struct {
   BitBoard pcs[12];
   Accumulator values;
-} AccumulatorKingState;
+} ALIGN AccumulatorKingState;
 
-typedef AccumulatorKingState AccumulatorRefreshTable[2][2 * N_KING_BUCKETS];
+typedef AccumulatorKingState AccumulatorRefreshTable[2][2 * N_KING_BUCKETS] ALIGN;
 
 typedef struct {
   BitBoard pcs, sqs;

--- a/src/util.h
+++ b/src/util.h
@@ -25,7 +25,6 @@
 #define stringize_(x) #x
 #define stringize(x)  stringize_(x)
 
-#define UNROLL __attribute__((optimize("unroll-loops")))
 #define INLINE static inline __attribute__((always_inline))
 
 long GetTimeMS();

--- a/src/util.h
+++ b/src/util.h
@@ -25,6 +25,7 @@
 #define stringize_(x) #x
 #define stringize(x)  stringize_(x)
 
+#define UNROLL __attribute__((optimize("unroll-loops")))
 #define INLINE static inline __attribute__((always_inline))
 
 long GetTimeMS();


### PR DESCRIPTION
Bench: 5801393

Someone's investigate revealed that GCC tends to neglect unrolling loops. This applied to Berserks auto-vectorized nnue update code. Modifying this to chunk in sizes of 256 generated better assembly. Along with this, two memcpys were able to be simplified into a single one on refresh code.

Overall speedup ~6% nps.

**STC**
```
ELO   | 7.24 +- 5.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 7536 W: 1837 L: 1680 D: 4019
```

Not tested at LTC.