### PR TITLE
Time Management based on overall search score difference

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -49,18 +49,18 @@ void Bench() {
   for (int i = 0; i < NUM_BENCH_POSITIONS; i++) {
     ParseFen(benchmarks[i], &board);
 
-    SearchResults results = {0};
     TTClear();
     ResetThreadPool(threads);
-    InitPool(&board, &params, threads, &results);
+    InitPool(&board, &params, threads);
 
     params.start = GetTimeMS();
-    BestMove(&board, &params, threads, &results);
+    BestMove(&board, &params, threads);
     times[i] = GetTimeMS() - params.start;
 
-    bestMoves[i] = results.bestMoves[results.depth];
-    scores[i]    = results.scores[results.depth];
-    nodes[i]     = threads[0].data.nodes;
+    SearchResults* results = &threads->results;
+    bestMoves[i]           = results->bestMoves[results->depth];
+    scores[i]              = results->scores[results->depth];
+    nodes[i]               = threads[0].data.nodes;
   }
   long totalTime = GetTimeMS() - startTime;
 

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 202209251606
+VERSION  = 20221001
 MAIN_NETWORK = networks/berserk-c982d9682d4e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -243,9 +243,8 @@ void* Search(void* arg) {
 
       if (PONDERING) continue;
 
-      Score searchScoreDiff    = results->scores[depth - 3] - results->scores[depth];
       Score prevScoreDiff      = results->prevScore - results->scores[depth];
-      double scoreChangeFactor = 0.1 + 0.0275 * searchScoreDiff + 0.0275 * prevScoreDiff;
+      double scoreChangeFactor = 0.1 + 0.055 * prevScoreDiff;
       scoreChangeFactor        = max(0.5, min(1.5, scoreChangeFactor));
 
       int64_t bestMoveNodes  = data->tm[FromTo(results->bestMoves[depth])];

--- a/src/search.c
+++ b/src/search.c
@@ -243,8 +243,9 @@ void* Search(void* arg) {
 
       if (PONDERING) continue;
 
+      Score searchScoreDiff    = results->scores[depth - 3] - results->scores[depth];
       Score prevScoreDiff      = results->prevScore - results->scores[depth];
-      double scoreChangeFactor = 0.1 + 0.055 * prevScoreDiff;
+      double scoreChangeFactor = 0.1 + 0.0275 * searchScoreDiff + 0.0275 * prevScoreDiff;
       scoreChangeFactor        = max(0.5, min(1.5, scoreChangeFactor));
 
       int64_t bestMoveNodes  = data->tm[FromTo(results->bestMoves[depth])];

--- a/src/search.h
+++ b/src/search.h
@@ -41,7 +41,7 @@
 void InitPruningAndReductionTables();
 
 void* UCISearch(void* arg);
-void BestMove(Board* board, SearchParams* params, ThreadData* threads, SearchResults* results);
+void BestMove(Board* board, SearchParams* params, ThreadData* threads);
 void* Search(void* arg);
 int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV* pv);
 int Quiesce(int alpha, int beta, ThreadData* thread);

--- a/src/thread.c
+++ b/src/thread.c
@@ -44,6 +44,7 @@ ThreadData* CreatePool(int count) {
     threads[i].idx                 = i;
     threads[i].threads             = threads;
     threads[i].count               = count;
+    threads[i].results.depth       = 0;
     threads[i].accumulators[WHITE] = (Accumulator*) AlignedMalloc(sizeof(Accumulator) * (MAX_SEARCH_PLY + 1));
     threads[i].accumulators[BLACK] = (Accumulator*) AlignedMalloc(sizeof(Accumulator) * (MAX_SEARCH_PLY + 1));
   }
@@ -52,10 +53,13 @@ ThreadData* CreatePool(int count) {
 }
 
 // initialize a pool prepping to start a search
-void InitPool(Board* board, SearchParams* params, ThreadData* threads, SearchResults* results) {
+void InitPool(Board* board, SearchParams* params, ThreadData* threads) {
   for (int i = 0; i < threads->count; i++) {
-    threads[i].params  = params;
-    threads[i].results = results;
+    threads[i].params = params;
+
+    threads[i].results.prevScore =
+      threads[i].results.depth > 0 ? threads[i].results.scores[threads[i].results.depth] : UNKNOWN;
+    threads[i].results.depth = 0;
 
     threads[i].data.nodes    = 0;
     threads[i].data.seldepth = 0;
@@ -84,7 +88,7 @@ void InitPool(Board* board, SearchParams* params, ThreadData* threads, SearchRes
 
 void ResetThreadPool(ThreadData* threads) {
   for (int i = 0; i < threads->count; i++) {
-    threads[i].results = NULL;
+    threads[i].results.depth = 0;
 
     threads[i].data.nodes    = 0;
     threads[i].data.seldepth = 0;

--- a/src/thread.h
+++ b/src/thread.h
@@ -20,7 +20,7 @@
 #include "types.h"
 
 ThreadData* CreatePool(int count);
-void InitPool(Board* board, SearchParams* params, ThreadData* threads, SearchResults* results);
+void InitPool(Board* board, SearchParams* params, ThreadData* threads);
 void ResetThreadPool(ThreadData* threads);
 void FreeThreads(ThreadData* threads);
 uint64_t NodesSearched(ThreadData* threads);

--- a/src/types.h
+++ b/src/types.h
@@ -151,6 +151,7 @@ typedef struct {
 
 typedef struct {
   int depth;
+  Score prevScore;
   Score scores[MAX_SEARCH_PLY];
   Move bestMoves[MAX_SEARCH_PLY];
   Move ponderMoves[MAX_SEARCH_PLY];
@@ -167,7 +168,7 @@ struct ThreadData {
   jmp_buf exit;
 
   SearchParams* params;
-  SearchResults* results;
+  SearchResults results;
   SearchData data;
 
   Board board;


### PR DESCRIPTION
Bench: 4668255

Rather than just using an internal search score to drive time management. This method represents using the previous searches score as well to force Berserk to think longer as it's score is dropped, even if the search has flat lined.

This test did not pass SPRT at either STC or LTC, but would have passed regression at LTC which is why it's being merged.

ELO   | 3.26 +- 4.13 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 1.03 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 11824 W: 2637 L: 2526 D: 6661