### PR TITLE
Improving flag via GrandParent nodes. Adjust LMR to use a new formula + legal moves.

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20221001
+VERSION  = 20221003
 MAIN_NETWORK = networks/berserk-c982d9682d4e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -389,8 +389,14 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   if (!tt) TTPut(board->zobrist, INT8_MIN, UNKNOWN, TT_UNKNOWN, NULL_MOVE, data->ply, eval, ttPv);
 
   // getting better if eval has gone up
-  int improving = !board->checkers && data->ply >= 2 &&
-                  (data->evals[data->ply] > data->evals[data->ply - 2] || data->evals[data->ply - 2] == UNKNOWN);
+  int improving = 0;
+  if (!board->checkers && data->ply >= 2) {
+    if (data->ply >= 4 && data->evals[data->ply - 2] == UNKNOWN) {
+      improving = data->evals[data->ply] > data->evals[data->ply - 4] || data->evals[data->ply - 4] == UNKNOWN;
+    } else {
+      improving = data->evals[data->ply] > data->evals[data->ply - 2] || data->evals[data->ply - 2] == UNKNOWN;
+    }
+  }
 
   // reset moves to moves related to 1 additional ply
   data->skipMove[data->ply + 1]   = NULL_MOVE;


### PR DESCRIPTION
Bench: 4467773

**STC**
```
ELO   | 4.05 +- 3.18 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [-0.50, 3.00]
GAMES | N: 21336 W: 5099 L: 4850 D: 11387
```

**LTC**
```
ELO   | 3.37 +- 2.49 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 32536 W: 7232 L: 6916 D: 18388
```