### PR TITLE
Captures in LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -494,7 +494,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     int extension       = 0;
     int tactical        = IsTactical(move);
     int killerOrCounter = move == moves.killer1 || move == moves.killer2 || move == moves.counter;
-    int history         = GetQuietHistory(data, move, board->stm, oppThreat.sqs);
+    int history =
+      !tactical ? GetQuietHistory(data, move, board->stm, oppThreat.sqs) : GetTacticalHistory(data, board, move);
 
     if (bestScore > -MATE_BOUND) {
       if (!isRoot && legalMoves >= LMP[improving][depth]) skipQuiets = 1;
@@ -566,7 +567,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     // Late move reductions
     int R = 1;
-    if (depth > 2 && legalMoves > 1 && !tactical) {
+    if (depth > 2 && legalMoves > 1 && !(ttPv && IsCap(move))) {
       R = LMR[min(depth, 63)][min(legalMoves, 63)];
 
       // increase reduction on non-pv


### PR DESCRIPTION
Bench: 4304646

ELO   | 4.53 +- 3.09 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 22264 W: 5271 L: 4981 D: 12012

ELO   | 2.79 +- 2.17 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 42976 W: 9565 L: 9220 D: 24191