### PR TITLE
Don't increase reductions for cutnodes when the move is tactical

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20221108
+VERSION  = 20221118
 MAIN_NETWORK = networks/berserk-c982d9682d4e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -589,7 +589,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // idea from komodo/sf, explained by Don Daily here
       // https://talkchess.com/forum3/viewtopic.php?f=7&t=47577&start=10#p519741
       // and https://www.chessprogramming.org/Node_Types
-      if (cutnode) R++;
+      if (cutnode && !tactical) R++;
 
       // adjust reduction based on historical score
       R -= history / 20480;


### PR DESCRIPTION
Bench: 4617111

**STC**
ELO   | 4.61 +- 3.13 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 21688 W: 5113 L: 4825 D: 11750

**LTC**
ELO   | 3.44 +- 2.54 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 31376 W: 7007 L: 6696 D: 17673