### PR TITLE
Between search optimizations

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -38,7 +38,8 @@ char* benchmarks[]            = {
 void Bench() {
   Board board;
   SearchParams params = {.depth = 13, .multiPV = 1, .hitrate = 1000, .max = INT_MAX};
-  ThreadData* threads = CreatePool(1);
+  
+  CreatePool(1);
 
   Move bestMoves[NUM_BENCH_POSITIONS];
   int scores[NUM_BENCH_POSITIONS];
@@ -50,11 +51,11 @@ void Bench() {
     ParseFen(benchmarks[i], &board);
 
     TTClear();
-    ResetThreadPool(threads);
-    InitPool(&board, &params, threads);
+    ResetThreadPool();
+    InitPool(&board, &params);
 
     params.start = GetTimeMS();
-    BestMove(&board, &params, threads);
+    BestMove(&board, &params);
     times[i] = GetTimeMS() - params.start;
 
     SearchResults* results = &threads->results;

--- a/src/nn.c
+++ b/src/nn.c
@@ -75,10 +75,10 @@ int Predict(Board* board) {
   return OutputLayer(stm, xstm);
 }
 
-void ResetRefreshTable(Board* board) {
+void ResetRefreshTable(AccumulatorKingState* refreshTable[2]) {
   for (int c = WHITE; c <= BLACK; c++) {
     for (int b = 0; b < 2 * N_KING_BUCKETS; b++) {
-      AccumulatorKingState* state = &board->refreshTable[c][b];
+      AccumulatorKingState* state = &refreshTable[c][b];
       memcpy(state->values, INPUT_BIASES, sizeof(int16_t) * N_HIDDEN);
       memset(state->pcs, 0, sizeof(BitBoard) * 12);
     }

--- a/src/nn.h
+++ b/src/nn.h
@@ -20,7 +20,7 @@
 
 int Predict(Board* board);
 int OutputLayer(Accumulator stm, Accumulator xstm);
-void ResetRefreshTable(Board* board);
+void ResetRefreshTable(AccumulatorKingState* refreshTable[2]);
 void RefreshAccumulator(Accumulator accumulator, Board* board, const int perspective);
 void ResetAccumulator(Accumulator output, Board* board, const int perspective);
 

--- a/src/search.c
+++ b/src/search.c
@@ -479,7 +479,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
   while ((move = NextMove(&moves, board, skipQuiets))) {
     int64_t startingNodeCount = data->nodes;
-    // if (isRoot) data->tm[FromTo(move)] = 0;
+    if (isRoot) data->tm[FromTo(move)] = 0;
     
     if (isRoot && MoveSearchedByMultiPV(thread, move)) continue;
     if (isRoot && !MoveSearchable(params, move)) continue;

--- a/src/search.c
+++ b/src/search.c
@@ -79,15 +79,14 @@ void* UCISearch(void* arg) {
 
   Board* board         = args->board;
   SearchParams* params = args->params;
-  ThreadData* threads  = args->threads;
 
-  BestMove(board, params, threads);
+  BestMove(board, params);
 
   free(args);
   return NULL;
 }
 
-void BestMove(Board* board, SearchParams* params, ThreadData* threads) {
+void BestMove(Board* board, SearchParams* params) {
   Move bestMove;
   if ((bestMove = TBRootProbe(board))) {
     while (PONDERING)
@@ -95,8 +94,7 @@ void BestMove(Board* board, SearchParams* params, ThreadData* threads) {
 
     printf("bestmove %s\n", MoveToStr(bestMove, board));
   } else {
-    pthread_t pthreads[threads->count];
-    InitPool(board, params, threads);
+    InitPool(board, params);
 
     params->stopped = 0;
     TTUpdate();
@@ -133,9 +131,8 @@ void* Search(void* arg) {
   int beta       = CHECKMATE;
 
   board->acc = 0;
-  ResetRefreshTable(board);
-  RefreshAccumulator(board->accumulators[WHITE][board->acc], board, WHITE);
-  RefreshAccumulator(board->accumulators[BLACK][board->acc], board, BLACK);
+  RefreshAccumulator(board->accumulators[WHITE][0], board, WHITE);
+  RefreshAccumulator(board->accumulators[BLACK][0], board, BLACK);
 
   data->contempt[WHITE] = data->contempt[BLACK] = 0;
   SetContempt(data->contempt, board->stm);
@@ -482,7 +479,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
   while ((move = NextMove(&moves, board, skipQuiets))) {
     int64_t startingNodeCount = data->nodes;
-
+    // if (isRoot) data->tm[FromTo(move)] = 0;
+    
     if (isRoot && MoveSearchedByMultiPV(thread, move)) continue;
     if (isRoot && !MoveSearchable(params, move)) continue;
 

--- a/src/search.c
+++ b/src/search.c
@@ -479,7 +479,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
   while ((move = NextMove(&moves, board, skipQuiets))) {
     int64_t startingNodeCount = data->nodes;
-    if (isRoot) data->tm[FromTo(move)] = 0;
     
     if (isRoot && MoveSearchedByMultiPV(thread, move)) continue;
     if (isRoot && !MoveSearchable(params, move)) continue;

--- a/src/search.h
+++ b/src/search.h
@@ -41,7 +41,7 @@
 void InitPruningAndReductionTables();
 
 void* UCISearch(void* arg);
-void BestMove(Board* board, SearchParams* params, ThreadData* threads);
+void BestMove(Board* board, SearchParams* params);
 void* Search(void* arg);
 int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV* pv);
 int Quiesce(int alpha, int beta, ThreadData* thread);

--- a/src/thread.c
+++ b/src/thread.c
@@ -79,6 +79,8 @@ void InitPool(Board* board, SearchParams* params) {
     threads[i].data.ply      = 0;
     threads[i].data.tbhits   = 0;
 
+    memset(&threads[i].data.tm, 0, sizeof(threads[i].data.tm));
+
     // need full copies of the board
     memcpy(&threads[i].board, board, sizeof(Board));
     threads[i].board.accumulators[WHITE] = threads[i].accumulators[WHITE];

--- a/src/thread.h
+++ b/src/thread.h
@@ -19,11 +19,16 @@
 
 #include "types.h"
 
-ThreadData* CreatePool(int count);
-void InitPool(Board* board, SearchParams* params, ThreadData* threads);
-void ResetThreadPool(ThreadData* threads);
-void FreeThreads(ThreadData* threads);
-uint64_t NodesSearched(ThreadData* threads);
-uint64_t TBHits(ThreadData* threads);
+#include <pthread.h>
+
+extern ThreadData* threads;
+extern pthread_t* pthreads;
+
+void CreatePool(int count);
+void InitPool(Board* board, SearchParams* params);
+void ResetThreadPool();
+void FreeThreads();
+uint64_t NodesSearched();
+uint64_t TBHits();
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -46,8 +46,6 @@ typedef struct {
   Accumulator values;
 } ALIGN AccumulatorKingState;
 
-typedef AccumulatorKingState AccumulatorRefreshTable[2][2 * N_KING_BUCKETS] ALIGN;
-
 typedef struct {
   BitBoard pcs, sqs;
 } Threat;
@@ -69,7 +67,7 @@ typedef struct {
   uint64_t zobrist;      // zobrist hash of the position
 
   Accumulator* accumulators[2];
-  AccumulatorRefreshTable refreshTable;
+  AccumulatorKingState* refreshTable[2];
 
   int squares[64];         // piece per square
   BitBoard occupancies[3]; // 0 - white pieces, 1 - black pieces, 2 - both
@@ -163,6 +161,7 @@ struct ThreadData {
   int count, idx, multiPV, depth;
 
   Accumulator* accumulators[2];
+  AccumulatorKingState* refreshTable[2];
 
   ThreadData* threads;
   jmp_buf exit;
@@ -181,7 +180,6 @@ struct ThreadData {
 typedef struct {
   Board* board;
   SearchParams* params;
-  ThreadData* threads;
 } SearchArgs;
 
 // Move generation storage

--- a/src/uci.h
+++ b/src/uci.h
@@ -24,8 +24,8 @@ extern int CONTEMPT;
 
 void RootMoves(SimpleMoveList* moves, Board* board);
 
-void ParseGo(char* in, SearchParams* params, Board* board, ThreadData* threads);
-void ParsePosition(char* in, Board* board, ThreadData* threads);
+void ParseGo(char* in, SearchParams* params, Board* board);
+void ParsePosition(char* in, Board* board);
 void PrintUCIOptions();
 
 int ReadLine(char* in);


### PR DESCRIPTION
Bench: 4617111

A patch mostly to alleviate SMP issues with fast TCs due to many memory allocs and sets between searches.

**STC**
```
ELO   | 0.26 +- 1.92 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 57992 W: 13393 L: 13349 D: 31250
```

**SMP STC**
```
ELO   | 3.02 +- 3.56 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 1.24 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 16133 W: 3636 L: 3496 D: 9001
```