### PR TITLE
Fast Range over modulo for TT indexing

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -39,8 +39,6 @@ void Bench() {
   Board board;
   SearchParams params = {.depth = 13, .multiPV = 1, .hitrate = 1000, .max = INT_MAX};
   
-  CreatePool(1);
-
   Move bestMoves[NUM_BENCH_POSITIONS];
   int scores[NUM_BENCH_POSITIONS];
   int nodes[NUM_BENCH_POSITIONS];

--- a/src/berserk.c
+++ b/src/berserk.c
@@ -23,6 +23,7 @@
 #include "nn.h"
 #include "random.h"
 #include "search.h"
+#include "thread.h"
 #include "transposition.h"
 #include "types.h"
 #include "uci.h"
@@ -38,7 +39,8 @@ int main(int argc, char** argv) {
   InitAttacks();
 
   LoadDefaultNN();
-  TTInit(32);
+  CreatePool(1);
+  TTInit(16);
 
   // Compliance for OpenBench
   if (argc > 1 && !strncmp(argv[1], "bench", 5)) {

--- a/src/thread.c
+++ b/src/thread.c
@@ -29,7 +29,7 @@
 ThreadData* threads = NULL;
 pthread_t* pthreads = NULL;
 
-void* AlignedMalloc(int size) {
+void* AlignedMalloc(uint64_t size) {
   void* mem  = malloc(size + ALIGN_ON + sizeof(void*));
   void** ptr = (void**) ((uintptr_t) (mem + ALIGN_ON + sizeof(void*)) & ~(ALIGN_ON - 1));
   ptr[-1]    = mem;

--- a/src/thread.h
+++ b/src/thread.h
@@ -24,6 +24,8 @@
 extern ThreadData* threads;
 extern pthread_t* pthreads;
 
+void* AlignedMalloc(uint64_t size);
+void AlignedFree(void* ptr);
 void CreatePool(int count);
 void InitPool(Board* board, SearchParams* params);
 void ResetThreadPool();

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -20,8 +20,8 @@
 #include "types.h"
 
 #define NO_ENTRY    0ULL
-#define MEGABYTE    0x100000ULL
-#define BUCKET_SIZE 2
+#define MEGABYTE    (1024ull * 1024ull)
+#define BUCKET_SIZE 4
 
 typedef struct {
   uint32_t hash, move;
@@ -35,9 +35,9 @@ typedef struct {
 } TTBucket;
 
 typedef struct {
+  void* mem;
   TTBucket* buckets;
-  uint64_t mask;
-  uint64_t size;
+  uint64_t count;
   uint8_t age;
 } TTTable;
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -21,7 +21,7 @@
 
 #define NO_ENTRY    0ULL
 #define MEGABYTE    (1024ull * 1024ull)
-#define BUCKET_SIZE 4
+#define BUCKET_SIZE 2
 
 typedef struct {
   uint32_t hash, move;

--- a/src/uci.c
+++ b/src/uci.c
@@ -220,7 +220,7 @@ void ParsePosition(char* in, Board* board) {
 void PrintUCIOptions() {
   printf("id name Berserk " VERSION "\n");
   printf("id author Jay Honnold\n");
-  printf("option name Hash type spin default 32 min 4 max 65536\n");
+  printf("option name Hash type spin default 16 min 2 max 262144\n");
   printf("option name Threads type spin default 1 min 1 max 256\n");
   printf("option name SyzygyPath type string default <empty>\n");
   printf("option name MultiPV type spin default 1 min 1 max 256\n");
@@ -247,7 +247,6 @@ void UCILoop() {
   Board board;
   ParseFen(START_FEN, &board);
 
-  CreatePool(1);
   SearchParams searchParameters = {.quit = 0};
 
   setbuf(stdin, NULL);
@@ -347,10 +346,10 @@ void UCILoop() {
       } else
         printf("info string Invalid move!\n");
     } else if (!strncmp(in, "setoption name Hash value ", 26)) {
-      int mb                 = GetOptionIntValue(in);
-      mb                     = max(4, min(65536, mb));
-      int64_t bytesAllocated = TTInit(mb);
-      printf("info string set Hash to value %d (%" PRId64 " bytes)\n", mb, bytesAllocated);
+      int mb                  = GetOptionIntValue(in);
+      mb                      = max(2, min(262144, mb));
+      uint64_t bytesAllocated = TTInit(mb);
+      printf("info string set Hash to value %d (%" PRIu64 " bytes)\n", mb, bytesAllocated);
     } else if (!strncmp(in, "setoption name Threads value ", 29)) {
       int n = GetOptionIntValue(in);
       CreatePool(max(1, min(256, n)));

--- a/src/uci.c
+++ b/src/uci.c
@@ -220,7 +220,7 @@ void ParsePosition(char* in, Board* board) {
 void PrintUCIOptions() {
   printf("id name Berserk " VERSION "\n");
   printf("id author Jay Honnold\n");
-  printf("option name Hash type spin default 16 min 2 max 262144\n");
+  printf("option name Hash type spin default 16 min 2 max 131072\n");
   printf("option name Threads type spin default 1 min 1 max 256\n");
   printf("option name SyzygyPath type string default <empty>\n");
   printf("option name MultiPV type spin default 1 min 1 max 256\n");
@@ -347,7 +347,7 @@ void UCILoop() {
         printf("info string Invalid move!\n");
     } else if (!strncmp(in, "setoption name Hash value ", 26)) {
       int mb                  = GetOptionIntValue(in);
-      mb                      = max(2, min(262144, mb));
+      mb                      = max(2, min(131072, mb));
       uint64_t bytesAllocated = TTInit(mb);
       printf("info string set Hash to value %d (%" PRIu64 " bytes)\n", mb, bytesAllocated);
     } else if (!strncmp(in, "setoption name Threads value ", 29)) {


### PR DESCRIPTION
Bench: 4510458

Allows support of many hash sizes as well as up to 128gb.

**STC**
ELO   | 0.51 +- 2.08 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 48976 W: 11242 L: 11170 D: 26564