### PR TITLE
Remove depth requirement on eval adjustment

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -406,9 +406,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
   if (!isPV && !board->checkers) {
     // Our TT might have a more accurate evaluation score, use this
-    if (tt && tt->depth >= depth && ttScore != UNKNOWN) {
-      if (tt->flags & (ttScore > eval ? TT_LOWER : TT_UPPER)) eval = ttScore;
-    }
+    if (tt && ttScore != UNKNOWN && (tt->flags & (ttScore > eval ? TT_LOWER : TT_UPPER))) eval = ttScore;
 
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune


### PR DESCRIPTION
Bench: 4907877

**STC**
ELO   | 5.58 +- 3.54 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 17064 W: 4075 L: 3801 D: 9188

**LTC**
ELO   | 5.77 +- 3.55 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 16192 W: 3710 L: 3441 D: 9041