### PR TITLE
Introduce negative reductions when hash move is singular

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20221206
+VERSION  = 20221208
 MAIN_NETWORK = networks/berserk-c982d9682d4e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -472,7 +472,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   Move quiets[64];
   Move tacticals[64];
 
-  int legalMoves = 0, playedMoves = 0, numQuiets = 0, numTacticals = 0, skipQuiets = 0;
+  int legalMoves = 0, playedMoves = 0, numQuiets = 0, numTacticals = 0, skipQuiets = 0, singularExtension = 0;
   InitAllMoves(&moves, hashMove, data, oppThreat.sqs);
 
   while ((move = NextMove(&moves, board, skipQuiets))) {
@@ -533,6 +533,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       // no score failed above sBeta, so this is singular
       if (score < sBeta) {
+        singularExtension = 1;
+
         if (!isPV && score < sBeta - 35 && data->de[data->ply - 1] <= 6) {
           extension           = 2;
           data->de[data->ply] = data->de[data->ply - 1] + 1;
@@ -591,7 +593,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       R -= history / 20480;
 
       // prevent dropping into QS, extending, or reducing all extensions
-      R = min(depth - 1, max(R, 1));
+      R = min(depth - 1, max(R, !singularExtension));
     }
 
     // First move of a PV node

--- a/src/search.c
+++ b/src/search.c
@@ -603,7 +603,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // potentially reduced search
       score = -Negamax(-alpha - 1, -alpha, newDepth - R, 1, thread, &childPv);
 
-      if (score > alpha && R != 1) // failed high on a reducede search, try again
+      if (score > alpha && R > 1) // failed high on a reducede search, try again
         score = -Negamax(-alpha - 1, -alpha, newDepth - 1, !cutnode, thread, &childPv);
 
       if (score > alpha && (isRoot || score < beta)) // failed high again, do full window


### PR DESCRIPTION
Bench: 4452548

This is a play on the idea of singular quiet lmr found in stockfish. 

**STC**
```
ELO   | 2.13 +- 1.71 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 73080 W: 17185 L: 16738 D: 39157
```

**LTC**
```
ELO   | 3.01 +- 2.30 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 38208 W: 8520 L: 8189 D: 21499
```