### PR TITLE
Update Github Workflow to force Ubuntu 20.04

### DIFF
--- a/.github/workflows/berserk.yml
+++ b/.github/workflows/berserk.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         version: [8, 9, 10, 11]
     
     steps:


### PR DESCRIPTION
Bench: 4452548

GCC 8 does not exist on `ubuntu-latest`.