### PR TITLE
Increase LMR for quiet moves in cutnodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -596,7 +596,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // idea from komodo/sf, explained by Don Daily here
       // https://talkchess.com/forum3/viewtopic.php?f=7&t=47577&start=10#p519741
       // and https://www.chessprogramming.org/Node_Types
-      if (cutnode) R++;
+      if (cutnode) R += 1 + !tactical;
 
       // adjust reduction based on historical score
       R -= history / 20480;


### PR DESCRIPTION
Bench: 5552083

**STC**
```
ELO   | 5.75 +- 3.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 16872 W: 4172 L: 3893 D: 8807
```

**LTC**
```
ELO   | 3.03 +- 2.32 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 38360 W: 8750 L: 8415 D: 21195
```