### PR TITLE
Implement CFish sleeping thread pool

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -41,7 +41,7 @@ void Bench(int depth) {
 
   limits.depth = depth;
   limits.multiPV = 1;
-  limits.hitrate = 1000;
+  limits.hitrate = 4096;
   limits.max = INT_MAX;
   limits.timeset = 0;
 
@@ -59,13 +59,13 @@ void Bench(int depth) {
 
     limits.start = GetTimeMS();
     StartSearch(&board, 0);
-    ThreadWaitUntilSleep(threadPool.threads[0]);
+    ThreadWaitUntilSleep(Threads.threads[0]);
     times[i] = GetTimeMS() - limits.start;
 
-    SearchResults* results = &threadPool.threads[0]->results;
+    SearchResults* results = &Threads.threads[0]->results;
     bestMoves[i]           = results->bestMoves[results->depth];
     scores[i]              = results->scores[results->depth];
-    nodes[i]               = threadPool.threads[0]->nodes;
+    nodes[i]               = Threads.threads[0]->nodes;
   }
   long totalTime = GetTimeMS() - startTime;
 

--- a/src/bench.c
+++ b/src/bench.c
@@ -28,6 +28,7 @@
 #include "transposition.h"
 #include "types.h"
 #include "util.h"
+#include "uci.h"
 
 // Ethereal's bench set
 const int NUM_BENCH_POSITIONS = 50;
@@ -37,7 +38,12 @@ char* benchmarks[]            = {
 
 void Bench(int depth) {
   Board board;
-  SearchParams params = {.depth = depth, .multiPV = 1, .hitrate = 1000, .max = INT_MAX};
+
+  limits.depth = depth;
+  limits.multiPV = 1;
+  limits.hitrate = 1000;
+  limits.max = INT_MAX;
+  limits.timeset = 0;
 
   Move bestMoves[NUM_BENCH_POSITIONS];
   int scores[NUM_BENCH_POSITIONS];
@@ -50,11 +56,11 @@ void Bench(int depth) {
 
     TTClear();
     ResetThreadPool();
-    InitPool(&board, &params);
+    InitPool(&board);
 
-    params.start = GetTimeMS();
-    BestMove(&board, &params);
-    times[i] = GetTimeMS() - params.start;
+    limits.start = GetTimeMS();
+    BestMove(&board);
+    times[i] = GetTimeMS() - limits.start;
 
     SearchResults* results = &threads->results;
     bestMoves[i]           = results->bestMoves[results->depth];

--- a/src/bench.c
+++ b/src/bench.c
@@ -39,11 +39,11 @@ char* benchmarks[]            = {
 void Bench(int depth) {
   Board board;
 
-  limits.depth = depth;
-  limits.multiPV = 1;
-  limits.hitrate = 4096;
-  limits.max = INT_MAX;
-  limits.timeset = 0;
+  Limits.depth = depth;
+  Limits.multiPV = 1;
+  Limits.hitrate = 4096;
+  Limits.max = INT_MAX;
+  Limits.timeset = 0;
 
   Move bestMoves[NUM_BENCH_POSITIONS];
   int scores[NUM_BENCH_POSITIONS];
@@ -57,10 +57,10 @@ void Bench(int depth) {
     TTClear();
     SearchClear();
 
-    limits.start = GetTimeMS();
+    Limits.start = GetTimeMS();
     StartSearch(&board, 0);
     ThreadWaitUntilSleep(Threads.threads[0]);
-    times[i] = GetTimeMS() - limits.start;
+    times[i] = GetTimeMS() - Limits.start;
 
     SearchResults* results = &Threads.threads[0]->results;
     bestMoves[i]           = results->bestMoves[results->depth];

--- a/src/bench.c
+++ b/src/bench.c
@@ -55,17 +55,17 @@ void Bench(int depth) {
     ParseFen(benchmarks[i], &board);
 
     TTClear();
-    ResetThreadPool();
-    InitPool(&board);
+    SearchClear();
 
     limits.start = GetTimeMS();
-    BestMove(&board);
+    StartSearch(&board, 0);
+    ThreadWaitUntilSleep(threadPool.threads[0]);
     times[i] = GetTimeMS() - limits.start;
 
-    SearchResults* results = &threads->results;
+    SearchResults* results = &threadPool.threads[0]->results;
     bestMoves[i]           = results->bestMoves[results->depth];
     scores[i]              = results->scores[results->depth];
-    nodes[i]               = threads[0].nodes;
+    nodes[i]               = threadPool.threads[0]->nodes;
   }
   long totalTime = GetTimeMS() - startTime;
 
@@ -84,6 +84,4 @@ void Bench(int depth) {
   for (int i = 0; i < NUM_BENCH_POSITIONS; i++) totalNodes += nodes[i];
 
   printf("\nResults: %43" PRIu64 " nodes %8d nps\n\n", totalNodes, (int) (1000.0 * totalNodes / (totalTime + 1)));
-
-  free(threads);
 }

--- a/src/berserk.c
+++ b/src/berserk.c
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
   InitAttacks();
 
   LoadDefaultNN();
-  CreatePool(1);
+  ThreadsInit();
   TTInit(16);
 
   // Compliance for OpenBench

--- a/src/search.c
+++ b/src/search.c
@@ -819,13 +819,13 @@ int MoveSearchable(Move move) {
 void SearchClearThread(ThreadData* thread) {
   thread->results.depth = 0;
 
-  memset(thread->counters, 0, sizeof(*thread->counters));
-  memset(thread->hh, 0, sizeof(*thread->hh));
-  memset(thread->ch, 0, sizeof(*thread->ch));
-  memset(thread->th, 0, sizeof(*thread->th));
-  memset(thread->scores, 0, sizeof(*thread->scores));
-  memset(thread->bestMoves, 0, sizeof(*thread->bestMoves));
-  memset(thread->pvs, 0, sizeof(*thread->counters));
+  memset(&thread->counters, 0, sizeof(thread->counters));
+  memset(&thread->hh, 0, sizeof(thread->hh));
+  memset(&thread->ch, 0, sizeof(thread->ch));
+  memset(&thread->th, 0, sizeof(thread->th));
+  memset(&thread->scores, 0, sizeof(thread->scores));
+  memset(&thread->bestMoves, 0, sizeof(thread->bestMoves));
+  memset(&thread->pvs, 0, sizeof(thread->counters));
 }
 
 void SearchClear() {

--- a/src/search.c
+++ b/src/search.c
@@ -19,6 +19,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include <pthread.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -69,8 +70,7 @@ INLINE void CheckLimits(ThreadData* thread) {
   if (Threads.ponder) return;
 
   long elapsed = GetTimeMS() - Limits.start;
-  if ((Limits.timeset && elapsed >= Limits.max) || (Limits.nodes && NodesSearched() >= Limits.nodes))
-    Threads.stop = 1;
+  if ((Limits.timeset && elapsed >= Limits.max) || (Limits.nodes && NodesSearched() >= Limits.nodes)) Threads.stop = 1;
 }
 
 void StartSearch(Board* board, uint8_t ponder) {

--- a/src/search.c
+++ b/src/search.c
@@ -234,13 +234,11 @@ void Search(ThreadData* thread) {
       }
     }
 
-    if (mainThread) {
-      if (!Threads.stop) {
-        results->depth                      = thread->depth;
-        results->scores[thread->depth]      = thread->scores[0];
-        results->bestMoves[thread->depth]   = thread->bestMoves[0];
-        results->ponderMoves[thread->depth] = thread->pvs[0].count > 1 ? thread->pvs[0].moves[1] : NULL_MOVE;
-      }
+    if (mainThread && !Threads.stop) {
+      results->depth                      = thread->depth;
+      results->scores[thread->depth]      = thread->scores[0];
+      results->bestMoves[thread->depth]   = thread->bestMoves[0];
+      results->ponderMoves[thread->depth] = thread->pvs[0].count > 1 ? thread->pvs[0].moves[1] : NULL_MOVE;
 
       for (int i = 0; i < Limits.multiPV; i++)
         PrintInfo(&thread->pvs[i], thread->scores[i], thread, -CHECKMATE, CHECKMATE, i + 1, board);

--- a/src/search.c
+++ b/src/search.c
@@ -246,6 +246,17 @@ void Search(ThreadData* thread) {
 
     if (!mainThread) continue;
 
+    long elapsed = GetTimeMS() - limits.start;
+
+    if (limits.timeset && elapsed > limits.max) {
+      if (threadPool.ponder)
+        threadPool.stopOnPonderHit = 1;
+      else
+        threadPool.stop = 1;
+    }
+
+    if (thread->depth < 5) continue;
+
     if (limits.timeset && !threadPool.stop && !threadPool.stopOnPonderHit) {
       int sameBestMove       = results->bestMoves[thread->depth] == results->bestMoves[thread->depth - 1]; // same move?
       searchStability        = sameBestMove ? min(10, searchStability + 1) : 0; // increase how stable our best move is
@@ -261,7 +272,6 @@ void Search(ThreadData* thread) {
       double nodeCountFactor = max(0.5, pctNodesNotBest * 2 + 0.4);
       if (results->scores[thread->depth] >= TB_WIN_BOUND) nodeCountFactor = 0.5;
 
-      long elapsed = GetTimeMS() - limits.start;
       if (elapsed > limits.alloc * stabilityFactor * scoreChangeFactor * nodeCountFactor) {
         if (threadPool.ponder)
           threadPool.stopOnPonderHit = 1;

--- a/src/search.h
+++ b/src/search.h
@@ -40,8 +40,9 @@
 
 void InitPruningAndReductionTables();
 
-void* BestMove(void* arg);
-void* Search(void* arg);
+void StartSearch(Board* board, uint8_t ponder);
+void MainSearch();
+void Search(ThreadData* thread);
 int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV* pv, SearchStack* ss);
 int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss);
 
@@ -50,5 +51,7 @@ void PrintPV(PV* pv, Board* board);
 
 int MoveSearchedByMultiPV(ThreadData* thread, Move move);
 int MoveSearchable(Move move);
+void SearchClearThread(ThreadData* thread);
+void SearchClear();
 
 #endif

--- a/src/search.h
+++ b/src/search.h
@@ -40,8 +40,7 @@
 
 void InitPruningAndReductionTables();
 
-void* UCISearch(void* arg);
-void BestMove(Board* board, SearchParams* params);
+void* BestMove(void* arg);
 void* Search(void* arg);
 int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV* pv, SearchStack* ss);
 int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss);
@@ -50,6 +49,6 @@ void PrintInfo(PV* pv, int score, ThreadData* thread, int alpha, int beta, int m
 void PrintPV(PV* pv, Board* board);
 
 int MoveSearchedByMultiPV(ThreadData* thread, Move move);
-int MoveSearchable(SearchParams* params, Move move);
+int MoveSearchable(Move move);
 
 #endif

--- a/src/thread.c
+++ b/src/thread.c
@@ -64,9 +64,8 @@ void CreatePool(int count) {
 }
 
 // initialize a pool prepping to start a search
-void InitPool(Board* board, SearchParams* params) {
+void InitPool(Board* board) {
   for (int i = 0; i < threads->count; i++) {
-    threads[i].params   = params;
     threads[i].nodes    = 0;
     threads[i].tbhits   = 0;
     threads[i].seldepth = 1;

--- a/src/thread.h
+++ b/src/thread.h
@@ -17,19 +17,37 @@
 #ifndef THREAD_H
 #define THREAD_H
 
+#include <pthread.h>
+#include <stdatomic.h>
+
 #include "types.h"
 
-#include <pthread.h>
+typedef struct {
+  ThreadData* threads[256];
+  int count;
 
-extern ThreadData* threads;
-extern pthread_t* pthreads;
+  pthread_mutex_t mutex, lock;
+  pthread_cond_t sleep;
+
+  uint8_t init, searching, sleeping, stopOnPonderHit;
+  atomic_uchar ponder, stop;
+} ThreadPool;
+
+extern ThreadPool threadPool;
 
 void* AlignedMalloc(uint64_t size);
 void AlignedFree(void* ptr);
-void CreatePool(int count);
-void InitPool(Board* board);
-void ResetThreadPool();
-void FreeThreads();
+void ThreadWaitUntilSleep(ThreadData* thread);
+void ThreadWait(ThreadData* thread, atomic_uchar* cond);
+void ThreadWake(ThreadData* thread, int action);
+void ThreadIdle(ThreadData* thread);
+void* ThreadInit(void* arg);
+void ThreadCreate(int i);
+void ThreadDestroy(ThreadData* thread);
+void ThreadsSetNumber(int n);
+void ThreadsExit();
+void ThreadsInit();
+
 uint64_t NodesSearched();
 uint64_t TBHits();
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -27,7 +27,7 @@ extern pthread_t* pthreads;
 void* AlignedMalloc(uint64_t size);
 void AlignedFree(void* ptr);
 void CreatePool(int count);
-void InitPool(Board* board, SearchParams* params);
+void InitPool(Board* board);
 void ResetThreadPool();
 void FreeThreads();
 uint64_t NodesSearched();

--- a/src/thread.h
+++ b/src/thread.h
@@ -33,10 +33,8 @@ typedef struct {
   atomic_uchar ponder, stop;
 } ThreadPool;
 
-extern ThreadPool threadPool;
+extern ThreadPool Threads;
 
-void* AlignedMalloc(uint64_t size);
-void AlignedFree(void* ptr);
 void ThreadWaitUntilSleep(ThreadData* thread);
 void ThreadWait(ThreadData* thread, atomic_uchar* cond);
 void ThreadWake(ThreadData* thread, int action);

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -64,7 +64,7 @@ void TTFree() {
 }
 
 void TTClearPart(int idx) {
-  int count = threadPool.count;
+  int count = Threads.count;
 
   uint64_t size   = TT.count * sizeof(TTBucket);
   uint64_t slice  = (size + count - 1) / count;
@@ -76,8 +76,8 @@ void TTClearPart(int idx) {
 }
 
 inline void TTClear() {
-  for (int i = 0; i < threadPool.count; i++) ThreadWake(threadPool.threads[i], THREAD_TT_CLEAR);
-  for (int i = 0; i < threadPool.count; i++) ThreadWaitUntilSleep(threadPool.threads[i]);
+  for (int i = 0; i < Threads.count; i++) ThreadWake(Threads.threads[i], THREAD_TT_CLEAR);
+  for (int i = 0; i < Threads.count; i++) ThreadWaitUntilSleep(Threads.threads[i]);
 }
 
 inline void TTUpdate() {

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -47,6 +47,7 @@ extern TTTable TT;
 
 size_t TTInit(int mb);
 void TTFree();
+void TTClearPart(int idx);
 void TTClear();
 void TTUpdate();
 void TTPrefetch(uint64_t hash);

--- a/src/types.h
+++ b/src/types.h
@@ -143,7 +143,6 @@ struct ThreadData {
 
   jmp_buf exit;
 
-  SearchParams* params;
   SearchResults results;
   Board board;
 
@@ -163,7 +162,6 @@ struct ThreadData {
 
 typedef struct {
   Board* board;
-  SearchParams* params;
 } SearchArgs;
 
 // Move generation storage

--- a/src/types.h
+++ b/src/types.h
@@ -66,9 +66,6 @@ typedef struct {
   uint64_t piecesCounts; // "material key" - pieces left on the board
   uint64_t zobrist;      // zobrist hash of the position
 
-  Accumulator* accumulators[2];
-  AccumulatorKingState* refreshTable[2];
-
   int squares[64];         // piece per square
   BitBoard occupancies[3]; // 0 - white pieces, 1 - black pieces, 2 - both
   BitBoard pieces[12];     // individual piece data
@@ -84,6 +81,9 @@ typedef struct {
   uint64_t zobristHistory[MAX_SEARCH_PLY + 100];
   BitBoard checkersHistory[MAX_SEARCH_PLY + 100];
   BitBoard pinnedHistory[MAX_SEARCH_PLY + 100];
+
+  Accumulator* accumulators[2];
+  AccumulatorKingState* refreshTable[2];
 } Board;
 
 typedef struct {
@@ -133,21 +133,13 @@ typedef struct {
   Move ponderMoves[MAX_SEARCH_PLY];
 } SearchResults;
 
-enum {
-  THREAD_SLEEP, THREAD_SEARCH, THREAD_TT_CLEAR, THREAD_SEARCH_CLEAR, THREAD_EXIT, THREAD_RESUME
-};
+enum { THREAD_SLEEP, THREAD_SEARCH, THREAD_TT_CLEAR, THREAD_SEARCH_CLEAR, THREAD_EXIT, THREAD_RESUME };
 
 typedef struct ThreadData ThreadData;
 
 struct ThreadData {
-  int count, idx, multiPV, depth, seldepth;
+  int idx, multiPV, depth, seldepth;
   uint64_t nodes, tbhits;
-
-  int action;
-
-  pthread_t nativeThread;
-  pthread_mutex_t mutex;
-  pthread_cond_t sleep;
 
   Accumulator* accumulators[2];
   AccumulatorKingState* refreshTable[2];
@@ -167,6 +159,11 @@ struct ThreadData {
   int hh[2][2][2][64 * 64]; // history heuristic butterfly table (stm / threatened)
   int ch[12][64][12][64];   // continuation move history table
   int th[6][64][7];         // tactical (capture) history
+
+  int action, calls;
+  pthread_t nativeThread;
+  pthread_mutex_t mutex;
+  pthread_cond_t sleep;
 };
 
 typedef struct {

--- a/src/uci.c
+++ b/src/uci.c
@@ -273,10 +273,13 @@ void UCILoop() {
       PrintUCIOptions();
     } else if (!strncmp(in, "ponderhit", 9)) {
       threadPool.ponder = 0;
+      if (threadPool.stopOnPonderHit) threadPool.stop = 1;
       pthread_mutex_lock(&threadPool.lock);
-      if (threadPool.sleeping)
+      if (threadPool.sleeping) {
+        threadPool.stop = 1;
         ThreadWake(threadPool.threads[0], THREAD_RESUME);
-      threadPool.sleeping = 0;
+        threadPool.sleeping = 0;
+      }
       pthread_mutex_unlock(&threadPool.lock);
     } else if (!strncmp(in, "board", 5)) {
       PrintBoard(&board);

--- a/src/uci.c
+++ b/src/uci.c
@@ -44,7 +44,7 @@ int PONDER_ENABLED = 0;
 int CHESS_960      = 0;
 int CONTEMPT       = 12;
 
-SearchParams limits;
+SearchParams Limits;
 
 void RootMoves(SimpleMoveList* moves, Board* board) {
   moves->count = 0;
@@ -60,15 +60,15 @@ void RootMoves(SimpleMoveList* moves, Board* board) {
 void ParseGo(char* in, Board* board) {
   in += 3;
 
-  limits.depth            = MAX_SEARCH_PLY;
-  limits.start            = GetTimeMS();
-  limits.timeset          = 0;
-  limits.stopped          = 0;
-  limits.quit             = 0;
-  limits.multiPV          = MULTI_PV;
-  limits.searchMoves      = 0;
-  limits.searchable.count = 0;
-  limits.infinite         = 0;
+  Limits.depth            = MAX_SEARCH_PLY;
+  Limits.start            = GetTimeMS();
+  Limits.timeset          = 0;
+  Limits.stopped          = 0;
+  Limits.quit             = 0;
+  Limits.multiPV          = MULTI_PV;
+  Limits.searchMoves      = 0;
+  Limits.searchable.count = 0;
+  Limits.infinite         = 0;
 
   char* ptrChar = in;
   int perft = 0, movesToGo = -1, moveTime = -1, time = -1, inc = 0, depth = -1, nodes = 0, ponder = 0;
@@ -76,7 +76,7 @@ void ParseGo(char* in, Board* board) {
   SimpleMoveList rootMoves;
   RootMoves(&rootMoves, board);
 
-  if ((ptrChar = strstr(in, "infinite"))) limits.infinite = 1;
+  if ((ptrChar = strstr(in, "infinite"))) Limits.infinite = 1;
 
   if ((ptrChar = strstr(in, "perft"))) perft = atoi(ptrChar + 6);
 
@@ -106,12 +106,12 @@ void ParseGo(char* in, Board* board) {
   }
 
   if ((ptrChar = strstr(in, "searchmoves"))) {
-    limits.searchMoves = 1;
+    Limits.searchMoves = 1;
 
     for (char* moves = strtok(ptrChar + 12, " "); moves != NULL; moves = strtok(NULL, " "))
       for (int i = 0; i < rootMoves.count; i++)
         if (!strcmp(MoveToStr(rootMoves.moves[i], board), moves))
-          limits.searchable.moves[limits.searchable.count++] = rootMoves.moves[i];
+          Limits.searchable.moves[Limits.searchable.count++] = rootMoves.moves[i];
   }
 
   if (perft) {
@@ -119,54 +119,54 @@ void ParseGo(char* in, Board* board) {
     return;
   }
 
-  limits.depth = depth;
-  limits.nodes = nodes;
+  Limits.depth = depth;
+  Limits.nodes = nodes;
 
-  if (limits.nodes)
-    limits.hitrate = min(4096, max(1, limits.nodes / 100));
+  if (Limits.nodes)
+    Limits.hitrate = min(4096, max(1, Limits.nodes / 100));
   else
-    limits.hitrate = 4096;
+    Limits.hitrate = 4096;
 
   // "movetime" is essentially making a move with 1 to go for TC
   if (moveTime != -1) {
-    limits.timeset = 1;
-    limits.alloc   = moveTime;
-    limits.max     = moveTime;
+    Limits.timeset = 1;
+    Limits.alloc   = moveTime;
+    Limits.max     = moveTime;
   } else {
     if (time != -1) {
-      limits.timeset = 1;
+      Limits.timeset = 1;
 
       if (movesToGo == -1) {
         int total = max(1, time + 50 * inc - MOVE_OVERHEAD);
 
-        limits.alloc = min(time * 0.33, total / 20.0);
+        Limits.alloc = min(time * 0.33, total / 20.0);
       } else {
         int total = max(1, time + movesToGo * inc - MOVE_OVERHEAD);
 
-        limits.alloc = min(time * 0.9, (0.9 * total) / max(1, movesToGo / 2.5));
+        Limits.alloc = min(time * 0.9, (0.9 * total) / max(1, movesToGo / 2.5));
       }
 
-      limits.max = min(time * 0.75, limits.alloc * 5.5);
+      Limits.max = min(time * 0.75, Limits.alloc * 5.5);
     } else {
       // no time control
-      limits.timeset = 0;
-      limits.max     = INT_MAX;
+      Limits.timeset = 0;
+      Limits.max     = INT_MAX;
     }
   }
 
-  limits.multiPV = min(limits.multiPV, limits.searchMoves ? limits.searchable.count : rootMoves.count);
-  if (rootMoves.count == 1 && limits.timeset) limits.max = min(250, limits.max);
+  Limits.multiPV = min(Limits.multiPV, Limits.searchMoves ? Limits.searchable.count : rootMoves.count);
+  if (rootMoves.count == 1 && Limits.timeset) Limits.max = min(250, Limits.max);
 
-  if (depth <= 0) limits.depth = MAX_SEARCH_PLY - 1;
+  if (depth <= 0) Limits.depth = MAX_SEARCH_PLY - 1;
 
   printf("info string time %d start %ld alloc %d max %d depth %d timeset %d searchmoves %d\n",
          time,
-         limits.start,
-         limits.alloc,
-         limits.max,
-         limits.depth,
-         limits.timeset,
-         limits.searchable.count);
+         Limits.start,
+         Limits.alloc,
+         Limits.max,
+         Limits.depth,
+         Limits.timeset,
+         Limits.searchable.count);
 
   StartSearch(board, ponder);
 }

--- a/src/uci.h
+++ b/src/uci.h
@@ -21,7 +21,7 @@
 
 extern int CHESS_960;
 extern int CONTEMPT;
-extern SearchParams limits;
+extern SearchParams Limits;
 
 void RootMoves(SimpleMoveList* moves, Board* board);
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -21,10 +21,11 @@
 
 extern int CHESS_960;
 extern int CONTEMPT;
+extern SearchParams limits;
 
 void RootMoves(SimpleMoveList* moves, Board* board);
 
-void ParseGo(char* in, SearchParams* params, Board* board);
+void ParseGo(char* in, Board* board);
 void ParsePosition(char* in, Board* board);
 void PrintUCIOptions();
 

--- a/src/util.h
+++ b/src/util.h
@@ -17,6 +17,8 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <stdlib.h>
+
 #include "types.h"
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))
@@ -30,5 +32,16 @@
 #define load_rlx(x) atomic_load_explicit(&(x), memory_order_relaxed)
 
 long GetTimeMS();
+
+INLINE void* AlignedMalloc(uint64_t size) {
+  void* mem  = malloc(size + ALIGN_ON + sizeof(void*));
+  void** ptr = (void**) ((uintptr_t) (mem + ALIGN_ON + sizeof(void*)) & ~(ALIGN_ON - 1));
+  ptr[-1]    = mem;
+  return ptr;
+}
+
+INLINE void AlignedFree(void* ptr) {
+  free(((void**) ptr)[-1]);
+}
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,8 @@
 
 #define INLINE static inline __attribute__((always_inline))
 
+#define load_rlx(x) atomic_load_explicit(&(x), memory_order_relaxed)
+
 long GetTimeMS();
 
 #endif


### PR DESCRIPTION
Bench: 4803004

Patch shows minor regression at SMP, but merging regardless. Patch will improve reliability at high thread counts, and I suspect the SMP regression is due to the VSTC TC.

**STC**
```
ELO   | 2.28 +- 3.06 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 23272 W: 5551 L: 5398 D: 12323
```

**STC SMP**
```
ELO   | -1.80 +- 1.73 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | -2.00 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 71049 W: 16196 L: 16564 D: 38289
```