### PR TITLE
Prevent positive score differences from impacting TM

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230105
+VERSION  = 20230106
 MAIN_NETWORK = networks/berserk-8eb49bcbe8a2.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -259,8 +259,10 @@ void Search(ThreadData* thread) {
 
       Score searchScoreDiff    = results->scores[thread->depth - 3] - results->scores[thread->depth];
       Score prevScoreDiff      = results->prevScore - results->scores[thread->depth];
-      double scoreChangeFactor = 0.1 + 0.0275 * searchScoreDiff + 0.0275 * prevScoreDiff;
-      scoreChangeFactor        = max(0.5, min(1.5, scoreChangeFactor));
+      double scoreChangeFactor = 0.1 +                                              //
+                                 0.0275 * searchScoreDiff * (searchScoreDiff > 0) + //
+                                 0.0275 * prevScoreDiff * (prevScoreDiff > 0);
+      scoreChangeFactor = max(0.5, min(1.5, scoreChangeFactor));
 
       uint64_t bestMoveNodes = thread->nodeCounts[FromTo(results->bestMoves[thread->depth])];
       double pctNodesNotBest = 1.0 - (double) bestMoveNodes / thread->nodes;


### PR DESCRIPTION
Bench: 4803004

**STC**
```
ELO   | -0.16 +- 1.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 83976 W: 19920 L: 19958 D: 44098
```

**LTC**
```
ELO   | -0.17 +- 2.49 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 1.12 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 33200 W: 7382 L: 7398 D: 18420
```