### PR TITLE
12 Byte TT Entries

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -27,8 +27,8 @@
 #include "thread.h"
 #include "transposition.h"
 #include "types.h"
-#include "util.h"
 #include "uci.h"
+#include "util.h"
 
 // Ethereal's bench set
 const int NUM_BENCH_POSITIONS = 50;
@@ -39,10 +39,10 @@ char* benchmarks[]            = {
 void Bench(int depth) {
   Board board;
 
-  Limits.depth = depth;
+  Limits.depth   = depth;
   Limits.multiPV = 1;
   Limits.hitrate = 4096;
-  Limits.max = INT_MAX;
+  Limits.max     = INT_MAX;
   Limits.timeset = 0;
 
   Move bestMoves[NUM_BENCH_POSITIONS];

--- a/src/eval.c
+++ b/src/eval.c
@@ -113,8 +113,8 @@ Score Evaluate(Board* board, ThreadData* thread) {
   Score knownEval = EvaluateKnownPositions(board);
   if (knownEval != UNKNOWN) return knownEval;
 
-  int16_t* stm     = board->accumulators[board->stm][board->acc];
-  int16_t* xstm    = board->accumulators[board->xstm][board->acc];
+  int16_t* stm  = board->accumulators[board->stm][board->acc];
+  int16_t* xstm = board->accumulators[board->xstm][board->acc];
 
   int score = OutputLayer(stm, xstm);
 

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -17,10 +17,10 @@
 #include "movegen.h"
 
 const int CASTLE_MAP[4][3] = {
-  { WHITE_KS, G1, F1 },
-  { WHITE_QS, C1, D1 },
-  { BLACK_KS, G8, F8 },
-  { BLACK_QS, C8, D8 },
+  {WHITE_KS, G1, F1},
+  {WHITE_QS, C1, D1},
+  {BLACK_KS, G8, F8},
+  {BLACK_QS, C8, D8},
 };
 
 ScoredMove* AddTacticalMoves(ScoredMove* moves, Board* board) {

--- a/src/nn.c
+++ b/src/nn.c
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "nn.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,7 +24,6 @@
 #include "board.h"
 #include "move.h"
 #include "movegen.h"
-#include "nn.h"
 #include "util.h"
 
 #define INCBIN_PREFIX
@@ -56,12 +57,10 @@ int OutputLayer(Accumulator stm, Accumulator xstm) {
   int result = OUTPUT_BIAS;
 
   for (size_t c = 0; c < N_HIDDEN; c += UNROLL)
-    for (size_t i = 0; i < UNROLL; i++)
-      result += max(stm[c + i], 0) * OUTPUT_WEIGHTS[c + i];
+    for (size_t i = 0; i < UNROLL; i++) result += max(stm[c + i], 0) * OUTPUT_WEIGHTS[c + i];
 
   for (size_t c = 0; c < N_HIDDEN; c += UNROLL)
-    for (size_t i = 0; i < UNROLL; i++)
-      result += max(xstm[c + i], 0) * OUTPUT_WEIGHTS[c + i + N_HIDDEN];
+    for (size_t i = 0; i < UNROLL; i++) result += max(xstm[c + i], 0) * OUTPUT_WEIGHTS[c + i + N_HIDDEN];
 
   return result / QUANTIZATION_PRECISION_IN / QUANTIZATION_PRECISION_OUT;
 }

--- a/src/thread.c
+++ b/src/thread.c
@@ -61,7 +61,7 @@ void ThreadWake(ThreadData* thread, int action) {
   pthread_cond_signal(&thread->sleep);
   pthread_mutex_unlock(&thread->mutex);
 }
- 
+
 // Idle loop that wakes into an action
 void ThreadIdle(ThreadData* thread) {
   while (1) {
@@ -95,9 +95,9 @@ void ThreadIdle(ThreadData* thread) {
 void* ThreadInit(void* arg) {
   int i = (intptr_t) arg;
 
-  ThreadData* thread          = calloc(1, sizeof(ThreadData));
-  thread->idx                 = i;
-  thread->results.depth       = 0;
+  ThreadData* thread    = calloc(1, sizeof(ThreadData));
+  thread->idx           = i;
+  thread->results.depth = 0;
 
   // Alloc all the necessary accumulators
   thread->accumulators[WHITE] = (Accumulator*) AlignedMalloc(sizeof(Accumulator) * (MAX_SEARCH_PLY + 1));
@@ -106,7 +106,7 @@ void* ThreadInit(void* arg) {
     (AccumulatorKingState*) AlignedMalloc(sizeof(AccumulatorKingState) * 2 * N_KING_BUCKETS);
   thread->refreshTable[BLACK] =
     (AccumulatorKingState*) AlignedMalloc(sizeof(AccumulatorKingState) * 2 * N_KING_BUCKETS);
-  
+
   ResetRefreshTable(thread->refreshTable);
 
   // Copy these onto the board for easier access within the engine

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -81,7 +81,7 @@ inline void TTClear() {
 }
 
 inline void TTUpdate() {
-  TT.age += 1;
+  TT.age += 0x10;
 }
 
 inline int TTScore(TTEntry* e, int ply) {
@@ -100,11 +100,11 @@ inline void TTPrefetch(uint64_t hash) {
 
 inline TTEntry* TTProbe(uint64_t hash) {
   TTEntry* bucket    = TT.buckets[TTIdx(hash)].entries;
-  uint32_t shortHash = hash >> 32;
+  uint16_t shortHash = hash >> 48;
 
   for (int i = 0; i < BUCKET_SIZE; i++)
     if (bucket[i].hash == shortHash) {
-      bucket[i].age = TT.age;
+      bucket[i].flags = TT.age | (bucket[i].flags & 0x0F);
       return &bucket[i];
     }
 
@@ -113,7 +113,7 @@ inline TTEntry* TTProbe(uint64_t hash) {
 
 inline void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval, int pv) {
   TTBucket* bucket   = &TT.buckets[TTIdx(hash)];
-  uint32_t shortHash = hash >> 32;
+  uint16_t shortHash = hash >> 48;
   TTEntry* toReplace = bucket->entries;
 
   if (score > MATE_BOUND)
@@ -136,17 +136,18 @@ inline void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move
       break;
     }
 
-    if (entry->depth - (256 + TT.age - entry->age) * 4 < toReplace->depth - (256 + TT.age - toReplace->age) * 4)
-      toReplace = entry;
+    int existingReplaceFactor = entry->depth - ((271 + TT.age - entry->flags) & 0xF0) / 4;
+    int currentReplaceFactor  = toReplace->depth - ((271 + TT.age - toReplace->flags) & 0xF0) / 4;
+
+    if (existingReplaceFactor < currentReplaceFactor) toReplace = entry;
   }
 
-  *toReplace = (TTEntry) {.flags = flag,
-                          .depth = depth,
-                          .eval  = eval,
-                          .score = score,
-                          .hash  = shortHash,
-                          .move  = move,
-                          .age   = TT.age};
+  toReplace->move  = move;
+  toReplace->hash  = shortHash;
+  toReplace->depth = depth;
+  toReplace->flags = TT.age | flag;
+  toReplace->score = score;
+  toReplace->eval  = eval;
 }
 
 inline int TTFull() {
@@ -156,7 +157,7 @@ inline int TTFull() {
   for (int i = 0; i < c; i++) {
     TTBucket b = TT.buckets[i];
     for (int j = 0; j < BUCKET_SIZE; j++) {
-      if (b.entries[j].hash && b.entries[j].age == TT.age) t++;
+      if (b.entries[j].hash && (b.entries[j].flags & 0xF0) == TT.age) t++;
     }
   }
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -21,17 +21,19 @@
 
 #define NO_ENTRY    0ULL
 #define MEGABYTE    (1024ull * 1024ull)
-#define BUCKET_SIZE 2
+#define BUCKET_SIZE 5
 
 typedef struct {
-  uint32_t hash, move;
+  uint16_t hash;
   int16_t eval, score;
+  uint8_t flags;
   int8_t depth;
-  uint8_t flags, age;
+  Move move;
 } TTEntry;
 
 typedef struct {
   TTEntry entries[BUCKET_SIZE];
+  uint32_t padding;
 } TTBucket;
 
 typedef struct {

--- a/src/uci.c
+++ b/src/uci.c
@@ -207,7 +207,7 @@ void ParsePosition(char* in, Board* board) {
 void PrintUCIOptions() {
   printf("id name Berserk " VERSION "\n");
   printf("id author Jay Honnold\n");
-  printf("option name Hash type spin default 16 min 2 max 131072\n");
+  printf("option name Hash type spin default 16 min 2 max 262144\n");
   printf("option name Threads type spin default 1 min 1 max 256\n");
   printf("option name SyzygyPath type string default <empty>\n");
   printf("option name MultiPV type spin default 1 min 1 max 256\n");
@@ -360,9 +360,13 @@ void UCILoop() {
         printf("info string Invalid move!\n");
     } else if (!strncmp(in, "setoption name Hash value ", 26)) {
       int mb                  = GetOptionIntValue(in);
-      mb                      = max(2, min(131072, mb));
+      mb                      = max(2, min(262144, mb));
       uint64_t bytesAllocated = TTInit(mb);
-      printf("info string set Hash to value %d (%" PRIu64 " bytes)\n", mb, bytesAllocated);
+      uint64_t totalEntries   = BUCKET_SIZE * bytesAllocated / sizeof(TTBucket);
+      printf("info string set Hash to value %d (%" PRIu64 " bytes) (%" PRIu64 " entries)\n",
+             mb,
+             bytesAllocated,
+             totalEntries);
     } else if (!strncmp(in, "setoption name Threads value ", 29)) {
       int n = GetOptionIntValue(in);
       ThreadsSetNumber(max(1, min(256, n)));


### PR DESCRIPTION
Bench: 4870236

Decrease the size of a TTEntry to 12. Combine this with 5 entries (up from 2) plus a 4 byte padding to get a 64 byte bucket. This effectively increases the number of TT entries from 4 per 64 bytes to 5 per 64 bytes.

This patched failed SPRT yellow, but merging regardless as it is unlikely it will lose Elo.

**STC**
```
ELO   | 0.76 +- 0.97 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | -2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 234600 W: 56584 L: 56072 D: 121944
```