### PR TITLE
QSearch ordering strictly based on Capture History

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -52,12 +52,12 @@ void UpdateHistories(Board* board,
                      int stm,
                      Move quiets[],
                      int nQ,
-                     Move tacticals[],
-                     int nT,
+                     Move captures[],
+                     int nC,
                      BitBoard threats) {
   int inc = min(7584, 16 * depth * depth + 480 * depth - 480);
 
-  if (!IsTactical(bestMove)) {
+  if (!IsCap(bestMove)) {
     AddKillerMove(ss, bestMove);
     AddHistoryHeuristic(&HH(stm, bestMove, threats), inc);
     UpdateCH(ss, bestMove, inc);
@@ -73,7 +73,7 @@ void UpdateHistories(Board* board,
   }
 
   // Update quiets
-  if (!IsTactical(bestMove)) {
+  if (!IsCap(bestMove)) {
     for (int i = 0; i < nQ; i++) {
       Move m = quiets[i];
       if (m == bestMove) continue;
@@ -83,9 +83,9 @@ void UpdateHistories(Board* board,
     }
   }
 
-  // Update tacticals
-  for (int i = 0; i < nT; i++) {
-    Move m = tacticals[i];
+  // Update captures
+  for (int i = 0; i < nC; i++) {
+    Move m = captures[i];
     if (m == bestMove) continue;
 
     int piece    = PieceType(Moving(m));
@@ -97,8 +97,6 @@ void UpdateHistories(Board* board,
 }
 
 int GetQuietHistory(SearchStack* ss, ThreadData* thread, Move move, int stm, BitBoard threats) {
-  if (IsTactical(move)) return 0;
-
   int history = HH(stm, move, threats);
   history += (*(ss - 1)->ch)[Moving(move)][To(move)];
   history += (*(ss - 2)->ch)[Moving(move)][To(move)];
@@ -106,7 +104,7 @@ int GetQuietHistory(SearchStack* ss, ThreadData* thread, Move move, int stm, Bit
   return history;
 }
 
-int GetTacticalHistory(ThreadData* thread, Board* board, Move m) {
+int GetCaptureHistory(ThreadData* thread, Board* board, Move m) {
   int piece    = PieceType(Moving(m));
   int to       = To(m);
   int captured = IsEP(m) ? PAWN : PieceType(board->squares[to]);

--- a/src/history.h
+++ b/src/history.h
@@ -21,7 +21,7 @@
 #include "types.h"
 
 #define HH(stm, m, threats) (thread->hh[stm][!getBit(threats, From(m))][!getBit(threats, To(m))][FromTo(m)])
-#define TH(p, e, c)         (thread->th[p][e][c])
+#define TH(p, e, c)         (thread->caph[p][e][c])
 
 void AddKillerMove(SearchStack* ss, Move move);
 void AddCounterMove(ThreadData* thread, Move move, Move parent);
@@ -34,10 +34,10 @@ void UpdateHistories(Board* board,
                      int stm,
                      Move quiets[],
                      int nQ,
-                     Move tacticals[],
-                     int nT,
+                     Move captures[],
+                     int nC,
                      BitBoard threats);
 int GetQuietHistory(SearchStack* ss, ThreadData* thread, Move move, int stm, BitBoard threats);
-int GetTacticalHistory(ThreadData* thread, Board* board, Move move);
+int GetCaptureHistory(ThreadData* thread, Board* board, Move move);
 
 #endif

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230108
+VERSION  = 20230109
 MAIN_NETWORK = networks/berserk-8eb49bcbe8a2.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/move.h
+++ b/src/move.h
@@ -41,8 +41,6 @@ extern const int CASTLING_ROOK[64];
 // just mask the from/to bits into a single int for indexing butterfly tables
 #define FromTo(move) ((int) (move) &0xfff)
 
-#define IsTactical(move) (((int) (move) &0x1f0000) >> 16)
-
 Move ParseMove(char* moveStr, Board* board);
 char* MoveToStr(Move move, Board* board);
 int IsRecapture(SearchStack* ss, Move move);

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -23,7 +23,7 @@ const int CASTLE_MAP[4][3] = {
   { BLACK_QS, C8, D8 },
 };
 
-ScoredMove* AddTacticalMoves(ScoredMove* moves, Board* board) {
+ScoredMove* AddNoisyMoves(ScoredMove* moves, Board* board) {
   return AddPseudoLegalMoves(moves, board, !QUIET);
 }
 

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -55,11 +55,15 @@ INLINE ScoredMove* AddMove(ScoredMove* moves, int from, int to, int moving, int 
   return moves;
 }
 
-INLINE ScoredMove* AddPromotions(ScoredMove* moves, int from, int to, int moving, int flags, const int stm) {
-  moves = AddMove(moves, from, to, moving, Piece(QUEEN, stm), flags);
-  moves = AddMove(moves, from, to, moving, Piece(ROOK, stm), flags);
-  moves = AddMove(moves, from, to, moving, Piece(BISHOP, stm), flags);
-  moves = AddMove(moves, from, to, moving, Piece(KNIGHT, stm), flags);
+INLINE ScoredMove*
+AddPromotions(ScoredMove* moves, int from, int to, int moving, int flags, const int stm, const int type) {
+  if (type != QUIET) {
+    moves = AddMove(moves, from, to, moving, Piece(QUEEN, stm), flags);
+  } else {
+    moves = AddMove(moves, from, to, moving, Piece(ROOK, stm), flags);
+    moves = AddMove(moves, from, to, moving, Piece(BISHOP, stm), flags);
+    moves = AddMove(moves, from, to, moving, Piece(KNIGHT, stm), flags);
+  }
   return moves;
 }
 
@@ -107,27 +111,27 @@ INLINE ScoredMove* AddPawnMoves(ScoredMove* moves, BitBoard opts, Board* board, 
         moves    = AddMove(moves, from, board->epSquare, Piece(PAWN, stm), NO_PROMO, EP);
       }
     }
+  }
 
-    // Promotions (both capture and non-capture)
-    valid             = PieceBB(PAWN, stm) & PromoRank(stm);
-    BitBoard sTargets = ShiftPawnDir(valid, stm) & ~OccBB(BOTH) & opts;
-    eTargets          = ShiftPawnCapE(valid, stm) & OccBB(xstm) & opts;
-    wTargets          = ShiftPawnCapW(valid, stm) & OccBB(xstm) & opts;
+  // Promotions (both capture and non-capture)
+  BitBoard valid    = PieceBB(PAWN, stm) & PromoRank(stm);
+  BitBoard sTargets = ShiftPawnDir(valid, stm) & ~OccBB(BOTH) & opts;
+  BitBoard eTargets = ShiftPawnCapE(valid, stm) & OccBB(xstm) & opts;
+  BitBoard wTargets = ShiftPawnCapW(valid, stm) & OccBB(xstm) & opts;
 
-    while (sTargets) {
-      int to = popAndGetLsb(&sTargets);
-      moves  = AddPromotions(moves, to - PawnDir(stm), to, Piece(PAWN, stm), QUIET, stm);
-    }
+  while (sTargets) {
+    int to = popAndGetLsb(&sTargets);
+    moves  = AddPromotions(moves, to - PawnDir(stm), to, Piece(PAWN, stm), QUIET, stm, type);
+  }
 
-    while (eTargets) {
-      int to = popAndGetLsb(&eTargets);
-      moves  = AddPromotions(moves, to - (PawnDir(stm) + E), to, Piece(PAWN, stm), CAPTURE, stm);
-    }
+  while (eTargets) {
+    int to = popAndGetLsb(&eTargets);
+    moves  = AddPromotions(moves, to - (PawnDir(stm) + E), to, Piece(PAWN, stm), CAPTURE, stm, type);
+  }
 
-    while (wTargets) {
-      int to = popAndGetLsb(&wTargets);
-      moves  = AddPromotions(moves, to - (PawnDir(stm) + W), to, Piece(PAWN, stm), CAPTURE, stm);
-    }
+  while (wTargets) {
+    int to = popAndGetLsb(&wTargets);
+    moves  = AddPromotions(moves, to - (PawnDir(stm) + W), to, Piece(PAWN, stm), CAPTURE, stm, type);
   }
 
   return moves;
@@ -188,9 +192,8 @@ INLINE ScoredMove* AddPseudoLegalMoves(ScoredMove* moves, Board* board, const in
   BitBoard pieceOpts = !board->checkers ? ALL :
                        type == QUIET    ? BetweenSquares(lsb(PieceBB(KING, color)), lsb(board->checkers)) :
                                           board->checkers;
-  BitBoard pawnOpts  = !board->checkers ? ALL :
-                                          BetweenSquares(lsb(PieceBB(KING, color)), lsb(board->checkers)) |
-                                           ((type != QUIET) * board->checkers);
+  BitBoard pawnOpts =
+    !board->checkers ? ALL : BetweenSquares(lsb(PieceBB(KING, color)), lsb(board->checkers)) | board->checkers;
 
   moves = AddPawnMoves(moves, pawnOpts, board, color, type);
   moves = AddPieceMoves(moves, pieceOpts, board, color, type, KNIGHT);
@@ -221,7 +224,7 @@ INLINE ScoredMove* AddLegalMoves(ScoredMove* moves, Board* board, const int type
   return moves;
 }
 
-ScoredMove* AddTacticalMoves(ScoredMove* moves, Board* board);
+ScoredMove* AddNoisyMoves(ScoredMove* moves, Board* board);
 ScoredMove* AddQuietMoves(ScoredMove* moves, Board* board);
 
 #endif

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -30,7 +30,7 @@
 const int MATERIAL_VALUES[7] = {100, 325, 325, 550, 1100, 0, 0};
 
 void InitAllMoves(MovePicker* picker, Move hashMove, ThreadData* thread, SearchStack* ss, BitBoard threats) {
-  picker->phase = MP_ALL;
+  picker->type  = MP_ALL;
   picker->phase = HASH_MOVE;
 
   picker->hashMove = hashMove;
@@ -44,7 +44,7 @@ void InitAllMoves(MovePicker* picker, Move hashMove, ThreadData* thread, SearchS
 }
 
 void InitTacticalMoves(MovePicker* picker, ThreadData* thread, int probcut) {
-  picker->phase = probcut ? MP_PC : MP_QS;
+  picker->type  = probcut ? MP_PC : MP_QS;
   picker->phase = GEN_TACTICAL_MOVES;
 
   picker->hashMove = NULL_MOVE;
@@ -57,7 +57,7 @@ void InitTacticalMoves(MovePicker* picker, ThreadData* thread, int probcut) {
 }
 
 void InitPerftMoves(MovePicker* picker, Board* board) {
-  picker->phase   = MP_PERFT;
+  picker->type    = MP_PERFT;
   picker->phase   = PERFT_MOVES;
   picker->current = picker->moves;
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -20,7 +20,7 @@
 #include "types.h"
 
 void InitAllMoves(MovePicker* picker, Move hashMove, ThreadData* thread, SearchStack* ss, BitBoard threats);
-void InitTacticalMoves(MovePicker* picker, ThreadData* thread, int probcut);
+void InitNoisyMoves(MovePicker* picker, ThreadData* thread, int probcut);
 void InitPerftMoves(MovePicker* picker, Board* board);
 Move NextMove(MovePicker* picker, Board* board, int skipQuiets);
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -20,7 +20,7 @@
 #include "types.h"
 
 void InitAllMoves(MovePicker* picker, Move hashMove, ThreadData* thread, SearchStack* ss, BitBoard threats);
-void InitTacticalMoves(MovePicker* picker, ThreadData* thread, int cutoff);
+void InitTacticalMoves(MovePicker* picker, ThreadData* thread, int probcut);
 void InitPerftMoves(MovePicker* picker, Board* board);
 Move NextMove(MovePicker* picker, Board* board, int skipQuiets);
 

--- a/src/search.c
+++ b/src/search.c
@@ -740,7 +740,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
     if (!IsLegal(move, board)) continue;
 
     if (bestScore > -MATE_BOUND) {
-      if (!SEE(board, move, 0)) continue;
+      if (!SEE(board, move, eval <= alpha - DELTA_CUTOFF)) continue;
     }
 
     ss->move = move;

--- a/src/search.c
+++ b/src/search.c
@@ -740,7 +740,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
     if (!IsLegal(move, board)) continue;
 
     if (bestScore > -MATE_BOUND) {
-      if (!SEE(board, move, eval <= alpha - DELTA_CUTOFF)) continue;
+      if (!SEE(board, move, 0)) continue;
     }
 
     ss->move = move;

--- a/src/search.c
+++ b/src/search.c
@@ -463,7 +463,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     int probBeta = beta + 110 - 30 * improving;
     if (depth > 4 && abs(beta) < TB_WIN_BOUND && ownThreat.pcs &&
         !(tt && tt->depth >= depth - 3 && ttScore < probBeta)) {
-      InitTacticalMoves(&mp, thread, 0);
+      InitTacticalMoves(&mp, thread, 1);
       while ((move = NextMove(&mp, board, 1))) {
         if (ss->skip == move) continue;
         if (!IsLegal(move, board)) continue;
@@ -734,12 +734,14 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
   Move move;
   MovePicker mp;
 
-  InitTacticalMoves(&mp, thread, eval <= alpha - DELTA_CUTOFF);
+  InitTacticalMoves(&mp, thread, 0);
 
   while ((move = NextMove(&mp, board, 1))) {
     if (!IsLegal(move, board)) continue;
 
-    if (mp.phase > PLAY_GOOD_TACTICAL) break;
+    if (bestScore > -MATE_BOUND) {
+      if (!SEE(board, move, eval <= alpha - DELTA_CUTOFF)) continue;
+    }
 
     ss->move = move;
     ss->ch   = &thread->ch[Moving(move)][To(move)];

--- a/src/search.h
+++ b/src/search.h
@@ -32,6 +32,9 @@
 #define SEE_PRUNE_CAPTURE_CUTOFF 90
 #define SEE_PRUNE_CUTOFF         15
 
+// delta pruning in QS
+#define DELTA_CUTOFF 50
+
 // base window value
 #define WINDOW 10
 

--- a/src/search.h
+++ b/src/search.h
@@ -32,9 +32,6 @@
 #define SEE_PRUNE_CAPTURE_CUTOFF 90
 #define SEE_PRUNE_CUTOFF         15
 
-// delta pruning in QS
-#define DELTA_CUTOFF 50
-
 // base window value
 #define WINDOW 10
 

--- a/src/types.h
+++ b/src/types.h
@@ -158,7 +158,7 @@ struct ThreadData {
   Move counters[12][64];    // counter move butterfly table
   int hh[2][2][2][64 * 64]; // history heuristic butterfly table (stm / threatened)
   int ch[12][64][12][64];   // continuation move history table
-  int th[6][64][7];         // tactical (capture) history
+  int caph[6][64][7];         // capture history
 
   int action, calls;
   pthread_t nativeThread;
@@ -172,18 +172,18 @@ typedef struct {
 
 // Move generation storage
 // moves/scores idx's match
-enum { ALL_MOVES, TACTICAL_MOVES };
+enum { ALL_MOVES, NOISY_MOVES };
 
 enum {
   HASH_MOVE,
-  GEN_TACTICAL_MOVES,
-  PLAY_GOOD_TACTICAL,
+  GEN_NOISY_MOVES,
+  PLAY_GOOD_NOISY,
   PLAY_KILLER_1,
   PLAY_KILLER_2,
   PLAY_COUNTER,
   GEN_QUIET_MOVES,
   PLAY_QUIETS,
-  PLAY_BAD_TACTICAL,
+  PLAY_BAD_NOISY,
   NO_MORE_MOVES,
   PERFT_MOVES,
 };

--- a/src/types.h
+++ b/src/types.h
@@ -193,12 +193,14 @@ typedef struct {
   Move move;
 } ScoredMove;
 
+enum { MP_ALL, MP_PC, MP_QS, MP_PERFT };
+
 typedef struct {
   ThreadData* thread;
   SearchStack* ss;
   Move hashMove, killer1, killer2, counter;
   BitBoard threats;
-  int seeCutoff, phase;
+  int seeCutoff, phase, type;
 
   ScoredMove *current, *end, *endBad;
   ScoredMove moves[MAX_MOVES];


### PR DESCRIPTION
Bench: 4224430

This is a two-fold patch where the major changes are:
- Adjust QSearch to strictly do it's ordering based on history.
  - Negative SEE moves still can be skipped iff another move has already been checked to avoid mate
- Remove under-promotions (captures and quiets) from PB and QS

**STC**
```
ELO   | 2.28 +- 1.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 65432 W: 15810 L: 15381 D: 34241
```

**LTC**
```
ELO   | 2.69 +- 2.11 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 46736 W: 10712 L: 10350 D: 25674
```