### PR TITLE
Utilize 128bit multiplication for TT indexing

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -90,8 +90,8 @@ inline int TTScore(TTEntry* e, int ply) {
   return e->score > MATE_BOUND ? e->score - ply : e->score < -MATE_BOUND ? e->score + ply : e->score;
 }
 
-inline uint32_t TTIdx(uint64_t hash) {
-  return ((uint32_t) hash * (uint64_t) TT.count) >> 32;
+inline uint64_t TTIdx(uint64_t hash) {
+  return ((unsigned __int128) hash * (unsigned __int128) TT.count) >> 64;
 }
 
 inline void TTPrefetch(uint64_t hash) {
@@ -100,7 +100,7 @@ inline void TTPrefetch(uint64_t hash) {
 
 inline TTEntry* TTProbe(uint64_t hash) {
   TTEntry* bucket    = TT.buckets[TTIdx(hash)].entries;
-  uint16_t shortHash = hash >> 48;
+  uint16_t shortHash = (uint16_t) hash;
 
   for (int i = 0; i < BUCKET_SIZE; i++)
     if (bucket[i].hash == shortHash) {
@@ -113,7 +113,7 @@ inline TTEntry* TTProbe(uint64_t hash) {
 
 inline void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval, int pv) {
   TTBucket* bucket   = &TT.buckets[TTIdx(hash)];
-  uint16_t shortHash = hash >> 48;
+  uint16_t shortHash = (uint16_t) hash;
   TTEntry* toReplace = bucket->entries;
 
   if (score > MATE_BOUND)

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -58,4 +58,6 @@ int TTScore(TTEntry* e, int ply);
 void TTPut(uint64_t hash, int8_t depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval, int pv);
 int TTFull();
 
+#define HASH_MAX ((int)(pow(2, 32) * sizeof(TTBucket) / MEGABYTE))
+
 #endif

--- a/src/uci.c
+++ b/src/uci.c
@@ -207,7 +207,7 @@ void ParsePosition(char* in, Board* board) {
 void PrintUCIOptions() {
   printf("id name Berserk " VERSION "\n");
   printf("id author Jay Honnold\n");
-  printf("option name Hash type spin default 16 min 2 max 262144\n");
+  printf("option name Hash type spin default 16 min 2 max %d\n", HASH_MAX);
   printf("option name Threads type spin default 1 min 1 max 256\n");
   printf("option name SyzygyPath type string default <empty>\n");
   printf("option name MultiPV type spin default 1 min 1 max 256\n");
@@ -356,7 +356,7 @@ void UCILoop() {
         printf("info string Invalid move!\n");
     } else if (!strncmp(in, "setoption name Hash value ", 26)) {
       int mb                  = GetOptionIntValue(in);
-      mb                      = max(2, min(262144, mb));
+      mb                      = max(2, min(HASH_MAX, mb));
       uint64_t bytesAllocated = TTInit(mb);
       uint64_t totalEntries   = BUCKET_SIZE * bytesAllocated / sizeof(TTBucket);
       printf("info string set Hash to value %d (%" PRIu64 " bytes) (%" PRIu64 " entries)\n",


### PR DESCRIPTION
Bench: 4187168

12-byte entries (#437) introduced a problem where position hash values we're essentially limited to 48 bits. This mitigates the issue by utilizing the entire 64 bit hash in the TT indexing calculation.

**STC**
```
ELO   | 2.71 +- 3.27 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 20624 W: 4990 L: 4829 D: 10805
```