### PR TITLE
Move Type in Continuation History

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230113
+VERSION  = 20230116
 MAIN_NETWORK = networks/berserk-bf1200bb0547.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -157,7 +157,7 @@ void Search(ThreadData* thread) {
   for (size_t i = 0; i < MAX_SEARCH_PLY; i++)
     (ss + i)->ply = i;
   for (size_t i = 1; i <= 4; i++)
-    (ss - i)->ch = &thread->ch[WHITE_PAWN][A1];
+    (ss - i)->ch = &thread->ch[0][WHITE_PAWN][A1];
 
   while (++thread->depth < MAX_SEARCH_PLY) {
 #if defined(_WIN32) || defined(_WIN64)
@@ -443,7 +443,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       R     = min(depth, R); // don't go too low
 
       ss->move = NULL_MOVE;
-      ss->ch   = &thread->ch[WHITE_PAWN][A1];
+      ss->ch   = &thread->ch[0][WHITE_PAWN][A1];
       MakeNullMove(board);
 
       score = -Negamax(-beta, -beta + 1, depth - R, !cutnode, thread, &childPv, ss + 1);
@@ -470,7 +470,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
           continue;
 
         ss->move = move;
-        ss->ch   = &thread->ch[Moving(move)][To(move)];
+        ss->ch   = &thread->ch[IsCap(move)][Moving(move)][To(move)];
         MakeMove(move, board);
 
         // qsearch to quickly check
@@ -584,7 +584,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       extension = 1;
 
     ss->move = move;
-    ss->ch   = &thread->ch[Moving(move)][To(move)];
+    ss->ch   = &thread->ch[IsCap(move)][Moving(move)][To(move)];
     MakeMove(move, board);
 
     // apply extensions
@@ -791,7 +791,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
       continue;
 
     ss->move = move;
-    ss->ch   = &thread->ch[Moving(move)][To(move)];
+    ss->ch   = &thread->ch[IsCap(move)][Moving(move)][To(move)];
     MakeMove(move, board);
 
     score = -Quiesce(-beta, -alpha, thread, ss + 1);

--- a/src/types.h
+++ b/src/types.h
@@ -165,10 +165,10 @@ struct ThreadData {
   RootMove rootMoves[MAX_MOVES];
   uint64_t nodeCounts[64 * 64];
 
-  Move counters[12][64];    // counter move butterfly table
-  int hh[2][2][2][64 * 64]; // history heuristic butterfly table (stm / threatened)
-  int ch[12][64][12][64];   // continuation move history table
-  int caph[6][64][7];       // capture history
+  Move counters[12][64];     // counter move butterfly table
+  int hh[2][2][2][64 * 64];  // history heuristic butterfly table (stm / threatened)
+  int ch[2][12][64][12][64]; // continuation move history table
+  int caph[6][64][7];        // capture history
 
   int action, calls;
   pthread_t nativeThread;


### PR DESCRIPTION
Bench: 4897182

**STC**
```
ELO   | 2.24 +- 1.80 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 67536 W: 16215 L: 15779 D: 35542
```

**LTC**
```
ELO   | 2.15 +- 1.73 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 69192 W: 15680 L: 15252 D: 38260
```