### PR TITLE
Add simple protections for search explosions due to extensions

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230116
+VERSION  = 20230116b
 MAIN_NETWORK = networks/berserk-bf1200bb0547.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 4897161

**STC**
```
ELO   | 1.69 +- 2.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-2.50, 0.50]
GAMES | N: 32520 W: 7945 L: 7787 D: 16788
```

**LTC**
```
ELO   | 0.07 +- 2.36 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 1.12 (-2.94, 2.94) [-2.50, 0.50]
GAMES | N: 37456 W: 8476 L: 8468 D: 20512
```