### PR TITLE
Remove SF Chess960 Cornered Bishop Logic

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -87,28 +87,6 @@ void Threats(Threat* threats, Board* board, int stm) {
   threats->sqs |= GetKingAttacks(lsb(PieceBB(KING, stm)));
 }
 
-// Idea from SF to correct positions not in classical chess
-// https://tcec-chess.com/#div=frc4ld&game=27&season=21
-Score FRCCorneredBishop(Board* board) {
-  static const Score v = 25;
-
-  Score fix = 0;
-
-  if (getBit(PieceBB(BISHOP, WHITE), A1) && getBit(PieceBB(PAWN, WHITE), B2))
-    fix -= (3 + !!getBit(OccBB(BOTH), B3)) * v;
-
-  if (getBit(PieceBB(BISHOP, WHITE), H1) && getBit(PieceBB(PAWN, WHITE), G2))
-    fix -= (3 + !!getBit(OccBB(BOTH), G3)) * v;
-
-  if (getBit(PieceBB(BISHOP, BLACK), A8) && getBit(PieceBB(PAWN, BLACK), B7))
-    fix += (3 + !!getBit(OccBB(BOTH), B6)) * v;
-
-  if (getBit(PieceBB(BISHOP, BLACK), H8) && getBit(PieceBB(PAWN, BLACK), G7))
-    fix += (3 + !!getBit(OccBB(BOTH), G6)) * v;
-
-  return board->stm == WHITE ? fix : -fix;
-}
-
 // Main evalution method
 Score Evaluate(Board* board, ThreadData* thread) {
   Score knownEval = EvaluateKnownPositions(board);
@@ -117,10 +95,6 @@ Score Evaluate(Board* board, ThreadData* thread) {
 
   Accumulator* acc = board->accumulators;
   int score        = OutputLayer(acc->values[board->stm], acc->values[board->xstm]);
-
-  // sf cornered bishop in FRC
-  if (CHESS_960)
-    score += FRCCorneredBishop(board);
 
   // static contempt
   score += thread->contempt[board->stm];


### PR DESCRIPTION
Bench: 4873539

This was an addition to cover gaps in non FRC training data. It is no longer necessary.

STC
```
ELO   | 2.92 +- 3.26 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 19488 W: 4449 L: 4285 D: 10754
```