### PR TITLE
Separate Move Pickers

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -17,11 +17,41 @@
 #ifndef MOVEPICK_H
 #define MOVEPICK_H
 
+#include "move.h"
+#include "movegen.h"
 #include "types.h"
+#include "util.h"
 
-void InitAllMoves(MovePicker* picker, Move hashMove, ThreadData* thread, SearchStack* ss, BitBoard threats);
-void InitNoisyMoves(MovePicker* picker, ThreadData* thread, int probcut);
-void InitPerftMoves(MovePicker* picker, Board* board);
+INLINE void InitNormalMovePicker(MovePicker* picker, Move hashMove, ThreadData* thread, SearchStack* ss, BitBoard threats) {
+  picker->phase = HASH_MOVE;
+
+  picker->hashMove = hashMove;
+  picker->killer1  = ss->killers[0];
+  picker->killer2  = ss->killers[1];
+  picker->counter  = thread->counters[Moving((ss - 1)->move)][To((ss - 1)->move)];
+
+  picker->threats = threats;
+  picker->thread  = thread;
+  picker->ss      = ss;
+}
+
+INLINE void InitPCMovePicker(MovePicker* picker, ThreadData* thread) {
+  picker->phase = PC_GEN_NOISY_MOVES;
+  picker->thread  = thread;
+}
+
+INLINE void InitQSMovePicker(MovePicker* picker, ThreadData* thread) {
+  picker->phase = QS_GEN_NOISY_MOVES;
+  picker->thread  = thread;
+}
+
+INLINE void InitPerftMovePicker(MovePicker* picker, Board* board) {
+  picker->phase   = PERFT_MOVES;
+  picker->current = picker->moves;
+
+  picker->end = AddPerftMoves(picker->moves, board);
+}
+
 Move NextMove(MovePicker* picker, Board* board, int skipQuiets);
 
 #endif

--- a/src/perft.c
+++ b/src/perft.c
@@ -30,7 +30,7 @@ uint64_t Perft(int depth, Board* board) {
 
   Move move;
   MovePicker mp;
-  InitPerftMoves(&mp, board);
+  InitPerftMovePicker(&mp, board);
 
   if (depth == 1)
     return mp.end - mp.moves;
@@ -54,7 +54,7 @@ void PerftTest(int depth, Board* board) {
 
   Move move;
   MovePicker mp;
-  InitPerftMoves(&mp, board);
+  InitPerftMovePicker(&mp, board);
 
   while ((move = NextMove(&mp, board, 0))) {
     MakeMoveUpdate(move, board, 0);

--- a/src/search.c
+++ b/src/search.c
@@ -466,7 +466,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     int probBeta = beta + 110 - 30 * improving;
     if (depth > 4 && abs(beta) < TB_WIN_BOUND && ownThreat.pcs &&
         !(tt && TTDepth(tt) >= depth - 3 && ttScore < probBeta)) {
-      InitNoisyMoves(&mp, thread, 1);
+      InitPCMovePicker(&mp, thread);
       while ((move = NextMove(&mp, board, 1))) {
         if (ss->skip == move)
           continue;
@@ -496,7 +496,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   Move quiets[64], captures[32];
 
   int legalMoves = 0, playedMoves = 0, skipQuiets = 0, singularExtension = 0;
-  InitAllMoves(&mp, hashMove, thread, ss, oppThreat.sqs);
+  InitNormalMovePicker(&mp, hashMove, thread, ss, oppThreat.sqs);
 
   while ((move = NextMove(&mp, board, skipQuiets))) {
     if (ss->skip == move)
@@ -791,7 +791,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
     bestScore = eval;
   }
 
-  InitNoisyMoves(&mp, thread, 0);
+  InitQSMovePicker(&mp, thread);
 
   while ((move = NextMove(&mp, board, 1))) {
     if (!IsLegal(move, board))

--- a/src/types.h
+++ b/src/types.h
@@ -201,6 +201,13 @@ enum {
   GEN_QUIET_MOVES,
   PLAY_QUIETS,
   PLAY_BAD_NOISY,
+  // ProbCut
+  PC_GEN_NOISY_MOVES,
+  PC_PLAY_GOOD_NOISY,
+  PC_PLAY_BAD_NOISY,
+  // QSearch
+  QS_GEN_NOISY_MOVES,
+  QS_PLAY_NOISY_MOVES,
   NO_MORE_MOVES,
   PERFT_MOVES,
 };
@@ -210,19 +217,12 @@ typedef struct {
   Move move;
 } ScoredMove;
 
-enum {
-  MP_ALL,
-  MP_PC,
-  MP_QS,
-  MP_PERFT
-};
-
 typedef struct {
   ThreadData* thread;
   SearchStack* ss;
   Move hashMove, killer1, killer2, counter;
   BitBoard threats;
-  int seeCutoff, phase, type;
+  int seeCutoff, phase;
 
   ScoredMove *current, *end, *endBad;
   ScoredMove moves[MAX_MOVES];

--- a/src/uci.c
+++ b/src/uci.c
@@ -50,7 +50,7 @@ void RootMoves(SimpleMoveList* moves, Board* board) {
   moves->count = 0;
 
   MovePicker mp;
-  InitPerftMoves(&mp, board);
+  InitPerftMovePicker(&mp, board);
 
   Move mv;
   while ((mv = NextMove(&mp, board, 0)))


### PR DESCRIPTION
Bench: 5536306

Each MovePicker is now independent. This is a minor speed boost (< 1%) and allows more flexibility in testing changes per usage."

**STC**
```
ELO   | 1.44 +- 3.90 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 14448 W: 3464 L: 3404 D: 7580
```