### PR TITLE
Hold TT Entry

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230126
+VERSION  = 20230128
 MAIN_NETWORK = networks/berserk-e9b73cc3d96f.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -22,7 +22,11 @@
 #include "types.h"
 #include "util.h"
 
-INLINE void InitNormalMovePicker(MovePicker* picker, Move hashMove, ThreadData* thread, SearchStack* ss, BitBoard threats) {
+INLINE void InitNormalMovePicker(MovePicker* picker,
+                                 Move hashMove,
+                                 ThreadData* thread,
+                                 SearchStack* ss,
+                                 BitBoard threats) {
   picker->phase = HASH_MOVE;
 
   picker->hashMove = hashMove;
@@ -36,13 +40,13 @@ INLINE void InitNormalMovePicker(MovePicker* picker, Move hashMove, ThreadData* 
 }
 
 INLINE void InitPCMovePicker(MovePicker* picker, ThreadData* thread) {
-  picker->phase = PC_GEN_NOISY_MOVES;
-  picker->thread  = thread;
+  picker->phase  = PC_GEN_NOISY_MOVES;
+  picker->thread = thread;
 }
 
 INLINE void InitQSMovePicker(MovePicker* picker, ThreadData* thread) {
-  picker->phase = QS_GEN_NOISY_MOVES;
-  picker->thread  = thread;
+  picker->phase  = QS_GEN_NOISY_MOVES;
+  picker->thread = thread;
 }
 
 INLINE void InitPerftMovePicker(MovePicker* picker, Board* board) {

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -59,8 +59,16 @@ void TTClearPart(int idx);
 void TTClear();
 void TTUpdate();
 void TTPrefetch(uint64_t hash);
-TTEntry* TTProbe(uint64_t hash);
-void TTPut(uint64_t hash, int depth, int16_t score, uint8_t flag, Move move, int ply, int16_t eval, int pv);
+TTEntry* TTProbe(uint64_t hash, int* hit);
+void TTPut(TTEntry* tt,
+           uint64_t hash,
+           int depth,
+           int16_t score,
+           uint8_t flag,
+           Move move,
+           int ply,
+           int16_t eval,
+           int pv);
 int TTFull();
 
 #define HASH_MAX ((int) (pow(2, 32) * sizeof(TTBucket) / MEGABYTE))


### PR DESCRIPTION
Bench: 5422070

When probing find the TT entry to replace as well. This saves time as during probe we are already iterating over the bucket. This patch almost no impact single threaded, however, this does patch a small bug with short entries of 0 being marked as hits on empty entries.

**STC**
```
ELO   | 1.69 +- 4.04 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 13360 W: 3189 L: 3124 D: 7047
```

**SMP STC Sanity Check**
```
ELO   | 1.11 +- 6.43 (95%)
CONF  | 5.0+0.05s Threads=8 Hash=64MB
GAMES | N: 5000 W: 1124 L: 1108 D: 2768
```