### PR TITLE
Increase hidden layer to 768 neurons

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230130
+VERSION  = 20230130b
 MAIN_NETWORK = networks/berserk-03b743679d3d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/makefile
+++ b/src/makefile
@@ -5,7 +5,7 @@ EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
 VERSION  = 20230130b
-MAIN_NETWORK = networks/berserk-03b743679d3d.nn
+MAIN_NETWORK = networks/berserk-f42dba5784a0.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG
 

--- a/src/nn.c
+++ b/src/nn.c
@@ -41,7 +41,8 @@ int16_t OUTPUT_WEIGHTS[2 * N_HIDDEN] ALIGN;
 int32_t OUTPUT_BIAS;
 
 #if defined(__AVX512F__)
-#define UNROLL     512
+#define UNROLL     256
+#define NUM_REGS 8
 #define regi_t     __m512i
 #define regi_load  _mm512_load_si512
 #define regi_sub   _mm512_sub_epi16
@@ -49,6 +50,7 @@ int32_t OUTPUT_BIAS;
 #define regi_store _mm512_store_si512
 #elif defined(__AVX2__)
 #define UNROLL     256
+#define NUM_REGS 16
 #define regi_t     __m256i
 #define regi_load  _mm256_load_si256
 #define regi_sub   _mm256_sub_epi16
@@ -56,6 +58,7 @@ int32_t OUTPUT_BIAS;
 #define regi_store _mm256_store_si256
 #else
 #define UNROLL     128
+#define NUM_REGS 16
 #define regi_t     __m128i
 #define regi_load  _mm_load_si128
 #define regi_sub   _mm_sub_epi16
@@ -63,7 +66,6 @@ int32_t OUTPUT_BIAS;
 #define regi_store _mm_store_si128
 #endif
 
-#define NUM_REGS 16
 
 INLINE void ApplyDelta(acc_t* dest, acc_t* src, Delta* delta) {
   regi_t regs[NUM_REGS];

--- a/src/types.h
+++ b/src/types.h
@@ -28,7 +28,7 @@
 #define N_KING_BUCKETS 16
 
 #define N_FEATURES (N_KING_BUCKETS * 12 * 64)
-#define N_HIDDEN   512
+#define N_HIDDEN   768
 #define N_OUTPUT   1
 
 #define ALIGN_ON 64
@@ -46,7 +46,7 @@ enum {
 typedef int16_t acc_t;
 
 typedef struct {
-  acc_t values[2][512] ALIGN;
+  acc_t values[2][N_HIDDEN] ALIGN;
 } Accumulator;
 
 typedef struct {


### PR DESCRIPTION
Bench: 5673033

**STC**
```
ELO   | 4.48 +- 4.80 (95%)
CONF  | 10.0+0.10s Threads=1 Hash=8MB
GAMES | N: 10000 W: 2552 L: 2423 D: 5025
```

**LTC**
```
ELO   | 10.69 +- 5.18 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 8128 W: 2043 L: 1793 D: 4292
```