### PR TITLE
No TT eval correction in QSearch

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -390,7 +390,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (ss->staticEval == UNKNOWN)
         eval = ss->staticEval = Evaluate(board, thread);
 
-      if (!isPV && ttScore != UNKNOWN && (tt->flags & (ttScore > eval ? TT_LOWER : TT_UPPER)))
+      if (ttScore != UNKNOWN && ((tt->flags & TT_EXACT) || (tt->flags & (ttScore > eval ? TT_LOWER : TT_UPPER))))
         eval = ttScore;
     } else if (!ss->skip) {
       eval = ss->staticEval = Evaluate(board, thread);
@@ -775,9 +775,6 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
       eval = ss->staticEval = tt->eval;
       if (ss->staticEval == UNKNOWN)
         eval = ss->staticEval = Evaluate(board, thread);
-
-      if (!isPV && ttScore != UNKNOWN && (tt->flags & (ttScore > eval ? TT_LOWER : TT_UPPER)))
-        eval = ttScore;
     } else {
       eval = ss->staticEval = Evaluate(board, thread);
 


### PR DESCRIPTION
Bench: 5710362

**STC**
```
ELO   | -1.30 +- 1.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | -0.98 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 104632 W: 23674 L: 24066 D: 56892
```