### PR TITLE
Add PV TT Eval correction in QSearch

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230207
+VERSION  = 20230207b
 MAIN_NETWORK = networks/berserk-f42dba5784a0.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -765,6 +765,9 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
       eval = ss->staticEval = tt->eval;
       if (ss->staticEval == UNKNOWN)
         eval = ss->staticEval = Evaluate(board, thread);
+
+      if (ttScore != UNKNOWN && (TTBound(tt) & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
+        eval = ttScore;
     } else {
       eval = ss->staticEval = Evaluate(board, thread);
 


### PR DESCRIPTION
Bench: 5745412

**STC**
```
ELO   | 4.71 +- 3.99 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 13360 W: 3167 L: 2986 D: 7207
```
