### PR TITLE
Add WDL Output and Normalize CP to 50% at 100cp

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -73,7 +73,7 @@ void Bench(int depth) {
     printf("Bench [#%2d]: bestmove %5s score %5d %12" PRIu64 " nodes %8d nps | %71s\n",
            i + 1,
            MoveToStr(bestMoves[i], &board),
-           scores[i],
+           (int) Normalize(scores[i]),
            nodes[i],
            (int) (1000.0 * nodes[i] / (times[i] + 1)),
            benchmarks[i]);

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230208b
+VERSION  = 20230209
 MAIN_NETWORK = networks/berserk-f42dba5784a0.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -302,7 +302,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
   if (!isRoot && board->fmr >= 3 && alpha < 0 && HasCycle(board, ss->ply)) {
     alpha = 2 - (thread->nodes & 0x3);
-    if (alpha >= beta) return alpha;
+    if (alpha >= beta)
+      return alpha;
   }
 
   // drop into noisy moves only
@@ -856,22 +857,33 @@ void PrintUCI(ThreadData* thread, int alpha, int beta, Board* board) {
 
     int realDepth = updated ? depth : Max(1, depth - 1);
     int bounded   = updated ? Max(alpha, Min(beta, thread->rootMoves[i].score)) : thread->rootMoves[i].previousScore;
-    int printable = bounded > MATE_BOUND  ? (CHECKMATE - bounded + 1) / 2 :
-                    bounded < -MATE_BOUND ? -(CHECKMATE + bounded) / 2 :
-                                            bounded;
-    char* type    = abs(bounded) > MATE_BOUND ? "mate" : "cp";
-    char* bound   = " ";
+    int printable = bounded > MATE_BOUND           ? (CHECKMATE - bounded + 1) / 2 :
+                    bounded < -MATE_BOUND          ? -(CHECKMATE + bounded) / 2 :
+                    abs(bounded) > WINNING_ENDGAME ? bounded : // don't normalize our fake tb scores or real tb scores
+                                                     Normalize(bounded); // convert to 50% WR at 100cp
+    char* type  = abs(bounded) > MATE_BOUND ? "mate" : "cp";
+    char* bound = " ";
     if (updated)
       bound = bounded >= beta ? " lowerbound " : bounded <= alpha ? " upperbound " : " ";
 
-    printf("info depth %d seldepth %d multipv %d score %s %d%snodes %" PRId64 " nps %" PRId64
-           " hashfull %d tbhits %" PRId64 " time %" PRId64 " pv ",
+    printf("info depth %d seldepth %d multipv %d score %s %d%s",
            realDepth,
            thread->rootMoves[i].seldepth,
            i + 1,
            type,
            printable,
-           bound,
+           bound);
+
+    if (SHOW_WDL) {
+      int ply  = Max(0, 2 * (board->moveNo - 1)) + board->stm;
+      int wdlW = WRModel(bounded, ply);
+      int wdlL = WRModel(-bounded, ply);
+      int wdlD = 1000 - wdlW - wdlL;
+
+      printf("wdl %d %d %d ", wdlW, wdlD, wdlL);
+    }
+
+    printf("nodes %" PRId64 " nps %" PRId64 " hashfull %d tbhits %" PRId64 " time %" PRId64 " pv ",
            nodes,
            nps,
            hashfull,

--- a/src/uci.h
+++ b/src/uci.h
@@ -19,9 +19,15 @@
 
 #include "types.h"
 
+extern int SHOW_WDL;
 extern int CHESS_960;
 extern int CONTEMPT;
 extern SearchParams Limits;
+
+// Normalization of a score to 50% WR at 100cp
+#define Normalize(s) ((s) / 1.63)
+
+int WRModel(Score s, int ply);
 
 void RootMoves(SimpleMoveList* moves, Board* board);
 


### PR DESCRIPTION
Bench: 5269425

Work on the PR is thanks to Vondele and his [WLD_model repository](https://github.com/vondele/WLD_model). Data used is STC Berserk gameplay on OB. LTC data will be generated over time, but this is a good starting place.

![Berserk_Fit](https://user-images.githubusercontent.com/25160789/217962468-0fc7fd01-2690-4b23-bfd7-954ed20c03c5.png)

