### PR TITLE
Utilize LMR Depth when move pruning quiets

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230210
+VERSION  = 20230210b
 MAIN_NETWORK = networks/berserk-f42dba5784a0.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -531,7 +531,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         skipQuiets = 1;
 
       if (!IsCap(move)) {
-        int lmrDepth = depth - LMR[Min(depth, 63)][Min(legalMoves, 63)];
+        int lmrDepth = Max(1, depth - LMR[Min(depth, 63)][Min(legalMoves, 63)]);
 
         if (lmrDepth < 9 && eval + 100 + 50 * lmrDepth + history / 128 <= alpha)
           skipQuiets = 1;

--- a/src/search.c
+++ b/src/search.c
@@ -531,10 +531,12 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         skipQuiets = 1;
 
       if (!IsCap(move)) {
-        if (depth < 9 && eval + 100 + 50 * depth + history / 128 <= alpha)
+        int lmrDepth = depth - LMR[Min(depth, 63)][Min(legalMoves, 63)];
+
+        if (lmrDepth < 9 && eval + 100 + 50 * lmrDepth + history / 128 <= alpha)
           skipQuiets = 1;
 
-        if (!SEE(board, move, STATIC_PRUNE[0][depth]))
+        if (!SEE(board, move, STATIC_PRUNE[0][lmrDepth]))
           continue;
       } else {
         if (mp.phase > PLAY_GOOD_NOISY && !SEE(board, move, STATIC_PRUNE[1][depth]))


### PR DESCRIPTION
Bench: 4779681

**STC**
```
ELO   | 3.94 +- 2.79 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 26840 W: 6226 L: 5922 D: 14692
```

**LTC**
```
ELO   | 3.37 +- 2.48 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 32240 W: 7088 L: 6775 D: 18377
```