### PR TITLE
Split Good and Bad captures with history and SEE

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -69,7 +69,7 @@ void UpdateHistories(Board* board,
       AddCounterMove(thread, bestMove, (ss - 1)->move);
 
   } else {
-    int piece    = PieceType(Moving(bestMove));
+    int piece    = Moving(bestMove);
     int to       = To(bestMove);
     int captured = IsEP(bestMove) ? PAWN : PieceType(board->squares[to]);
 
@@ -94,7 +94,7 @@ void UpdateHistories(Board* board,
     if (m == bestMove)
       continue;
 
-    int piece    = PieceType(Moving(m));
+    int piece    = Moving(m);
     int to       = To(m);
     int captured = IsEP(m) ? PAWN : PieceType(board->squares[to]);
 

--- a/src/history.h
+++ b/src/history.h
@@ -34,7 +34,7 @@ INLINE int GetQuietHistory(SearchStack* ss, ThreadData* thread, Move move, int s
 }
 
 INLINE int GetCaptureHistory(ThreadData* thread, Board* board, Move move) {
-  return TH(PieceType(Moving(move)), To(move), IsEP(move) ? PAWN : PieceType(board->squares[To(move)]));
+  return TH(Moving(move), To(move), IsEP(move) ? PAWN : PieceType(board->squares[To(move)]));
 }
 
 void UpdateHistories(Board* board,

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230213
+VERSION  = 20230215
 MAIN_NETWORK = networks/berserk-e3f526b26f50.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -82,11 +82,13 @@ Move NextMove(MovePicker* picker, Board* board, int skipQuiets) {
       // fallthrough
     case PLAY_GOOD_NOISY:
       if (picker->current != picker->end) {
-        Move move = Best(picker->current++, picker->end);
+        Move move = Best(picker->current, picker->end);
+        int score = picker->current->score;
+        picker->current++;
 
         if (move == picker->hashMove) {
           return NextMove(picker, board, skipQuiets);
-        } else if (!SEE(board, move, 0)) {
+        } else if (score < 10000 && !SEE(board, move, 0)) {
           *picker->endBad++ = *(picker->current - 1);
           return NextMove(picker, board, skipQuiets);
         } else {

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -56,7 +56,7 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
       current->score = GetQuietHistory(picker->ss, picker->thread, move, board->stm, picker->threats);
     else if (type == ST_CAPTURE)
       current->score =
-        GetCaptureHistory(picker->thread, board, move) + MATERIAL_VALUES[PieceType(board->squares[To(move)])] * 8;
+        GetCaptureHistory(picker->thread, board, move) / 16 + MATERIAL_VALUES[PieceType(board->squares[To(move)])];
     else if (type == ST_EVASION)
       current->score = IsCap(move) ? 1e7 + MATERIAL_VALUES[IsEP(move) ? PAWN : PieceType(board->squares[To(move)])] :
                                      GetQuietHistory(ss, thread, move, board->stm, picker->threats);
@@ -88,7 +88,7 @@ Move NextMove(MovePicker* picker, Board* board, int skipQuiets) {
 
         if (move == picker->hashMove) {
           return NextMove(picker, board, skipQuiets);
-        } else if (score < 10000 && !SEE(board, move, 0)) {
+        } else if (!SEE(board, move, -score / 2)) {
           *picker->endBad++ = *(picker->current - 1);
           return NextMove(picker, board, skipQuiets);
         } else {

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -27,8 +27,6 @@
 #include "transposition.h"
 #include "types.h"
 
-const int MATERIAL_VALUES[7] = {100, 325, 325, 550, 1100, 0, 0};
-
 Move Best(ScoredMove* current, ScoredMove* end) {
   ScoredMove* orig = current;
   ScoredMove* max  = current;
@@ -56,9 +54,9 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
       current->score = GetQuietHistory(picker->ss, picker->thread, move, board->stm, picker->threats);
     else if (type == ST_CAPTURE)
       current->score =
-        GetCaptureHistory(picker->thread, board, move) / 16 + MATERIAL_VALUES[PieceType(board->squares[To(move)])];
+        GetCaptureHistory(picker->thread, board, move) / 16 + SEE_VALUE[PieceType(board->squares[To(move)])];
     else if (type == ST_EVASION)
-      current->score = IsCap(move) ? 1e7 + MATERIAL_VALUES[IsEP(move) ? PAWN : PieceType(board->squares[To(move)])] :
+      current->score = IsCap(move) ? 1e7 + SEE_VALUE[IsEP(move) ? PAWN : PieceType(board->squares[To(move)])] :
                                      GetQuietHistory(ss, thread, move, board->stm, picker->threats);
 
     current++;

--- a/src/search.c
+++ b/src/search.c
@@ -544,7 +544,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         if (!SEE(board, move, STATIC_PRUNE[0][lmrDepth]))
           continue;
       } else {
-        if (mp.phase > PLAY_GOOD_NOISY && !SEE(board, move, STATIC_PRUNE[1][depth]))
+        if (!SEE(board, move, STATIC_PRUNE[1][depth]))
           continue;
       }
     }

--- a/src/types.h
+++ b/src/types.h
@@ -175,7 +175,7 @@ struct ThreadData {
   Move counters[12][64];         // counter move butterfly table
   int16_t hh[2][2][2][64 * 64];  // history heuristic butterfly table (stm / threatened)
   int16_t ch[2][12][64][12][64]; // continuation move history table
-  int16_t caph[6][64][7];        // capture history
+  int16_t caph[12][64][7];       // capture history
 
   int action, calls;
   pthread_t nativeThread;


### PR DESCRIPTION
Bench: 4380260

**STC**
ELO   | 1.92 +- 1.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 90184 W: 21043 L: 20545 D: 48596

**LTC**
ELO   | 2.85 +- 2.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 41336 W: 9128 L: 8789 D: 23419