### PR TITLE
Tweak history reductions in LMR

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 11
+VERSION  = 20230219
 MAIN_NETWORK = networks/berserk-e3f526b26f50.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -642,7 +642,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         R += 1 + !IsCap(move);
 
       // adjust reduction based on historical score
-      R -= history / 6144;
+      R -= history / 8192;
 
       // prevent dropping into QS, extending, or reducing all extensions
       R = Min(depth - 1, Max(R, !singularExtension));


### PR DESCRIPTION
Bench: 4309157

**STC**
```
ELO   | 0.78 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -0.45 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 40680 W: 9410 L: 9319 D: 21951
```

**LTC**
```
ELO   | 2.51 +- 1.99 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 51072 W: 11326 L: 10957 D: 28789
```