### PR TITLE
Select bestmove from any thread

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230224
+VERSION  = 20230225
 MAIN_NETWORK = networks/berserk-e3f526b26f50.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -96,8 +96,8 @@ void StartSearch(Board* board, uint8_t ponder) {
 }
 
 void MainSearch() {
-  ThreadData* thread = Threads.threads[0];
-  Board* board       = &thread->board;
+  ThreadData* mainThread = Threads.threads[0];
+  Board* board           = &mainThread->board;
 
   TTUpdate();
 
@@ -106,14 +106,14 @@ void MainSearch() {
   if (!bestMove) {
     for (int i = 1; i < Threads.count; i++)
       ThreadWake(Threads.threads[i], THREAD_SEARCH);
-    Search(thread);
+    Search(mainThread);
   }
 
   pthread_mutex_lock(&Threads.lock);
   if (!Threads.stop && (Threads.ponder || Limits.infinite)) {
     Threads.sleeping = 1;
     pthread_mutex_unlock(&Threads.lock);
-    ThreadWait(thread, &Threads.stop);
+    ThreadWait(mainThread, &Threads.stop);
   } else {
     pthread_mutex_unlock(&Threads.lock);
   }
@@ -124,12 +124,26 @@ void MainSearch() {
     for (int i = 1; i < Threads.count; i++)
       ThreadWaitUntilSleep(Threads.threads[i]);
 
-    bestMove = thread->rootMoves[0].move;
-    if (thread->rootMoves[0].pv.count > 1)
-      ponderMove = thread->rootMoves[0].pv.moves[1];
-  }
+    ThreadData* bestThread = mainThread;
+    for (int i = 1; i < Threads.count; i++) {
+      ThreadData* curr = Threads.threads[i];
 
-  thread->previousScore = thread->rootMoves[0].score;
+      int s = curr->rootMoves[0].score - bestThread->rootMoves[0].score;
+      int d = curr->depth - bestThread->depth;
+
+      if (s > 0 && (d >= 0 || curr->rootMoves[0].score >= MATE_BOUND))
+        bestThread = curr;
+    }
+
+    if (bestThread != mainThread)
+      PrintUCI(bestThread, -CHECKMATE, CHECKMATE, board);
+
+    bestMove = bestThread->rootMoves[0].move;
+    if (bestThread->rootMoves[0].pv.count > 1)
+      ponderMove = bestThread->rootMoves[0].pv.moves[1];
+
+    mainThread->previousScore = bestThread->rootMoves[0].score;
+  }
 
   printf("bestmove %s", MoveToStr(bestMove, board));
   if (ponderMove)
@@ -162,12 +176,13 @@ void Search(ThreadData* thread) {
 
   while (++thread->depth < MAX_SEARCH_PLY) {
 #if defined(_WIN32) || defined(_WIN64)
-    if (_setjmp(thread->exit, NULL))
-      break;
+    if (_setjmp(thread->exit, NULL)) {
 #else
-    if (setjmp(thread->exit))
-      break;
+    if (setjmp(thread->exit)) {
 #endif
+      thread->depth--; // hot exit means we didn't finish this depth.
+      break;
+    }
 
     if (Limits.depth && mainThread && thread->depth > Limits.depth)
       break;


### PR DESCRIPTION
Bench: 4309157

There is no change to single threaded conditions. In SMP this will choose the bestmove from any thread with either a better mate score or better score and better depth.

STC
```
ELO   | 6.00 +- 3.69 (95%)
SPRT  | 4.0+0.04s Threads=8 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 15589 W: 3703 L: 3434 D: 8452
```