### PR TITLE
Simplify Singular Extension allowing negative extensions in LMR

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230225
+VERSION  = 20230225b
 MAIN_NETWORK = networks/berserk-e3f526b26f50.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -522,7 +522,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   int numQuiets = 0, numCaptures = 0;
   Move quiets[64], captures[32];
 
-  int legalMoves = 0, playedMoves = 0, skipQuiets = 0, singularExtension = 0;
+  int legalMoves = 0, playedMoves = 0, skipQuiets = 0;
   InitNormalMovePicker(&mp, hashMove, thread, ss, oppThreat.sqs);
 
   while ((move = NextMove(&mp, board, skipQuiets))) {
@@ -599,8 +599,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
         // no score failed above sBeta, so this is singular
         if (score < sBeta) {
-          singularExtension = 1;
-
           if (!isPV && score < sBeta - 35 && ss->de <= 6) {
             extension = 2;
             ss->de    = (ss - 1)->de + 1;
@@ -664,7 +662,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       R -= history / 8192;
 
       // prevent dropping into QS, extending, or reducing all extensions
-      R = Min(depth - 1, Max(R, !singularExtension));
+      R = Min(depth - 1, Max(R, 1));
 
       score = -Negamax(-alpha - 1, -alpha, newDepth - R, 1, thread, &childPv, ss + 1);
 


### PR DESCRIPTION
Bench: 4084099

This seems to have been a good offset to HE.

**STC**
```
ELO   | -0.31 +- 1.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 102184 W: 23495 L: 23586 D: 55103
```

**LTC**
```
ELO   | -0.09 +- 1.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 81056 W: 17700 L: 17720 D: 45636
```