### PR TITLE
More double extensions

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230225b
+VERSION  = 20230226
 MAIN_NETWORK = networks/berserk-e3f526b26f50.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -599,7 +599,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
         // no score failed above sBeta, so this is singular
         if (score < sBeta) {
-          if (!isPV && score < sBeta - 35 && ss->de <= 6) {
+          if (!isPV && score < sBeta - 20 && ss->de <= 6) {
             extension = 2;
             ss->de    = (ss - 1)->de + 1;
           } else {


### PR DESCRIPTION
Bench: 4126688

**STC**
```
ELO   | 0.74 +- 1.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -1.62 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 130416 W: 30266 L: 29988 D: 70162
```

**LTC**
```
ELO   | 3.98 +- 2.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 25488 W: 5623 L: 5331 D: 14534
```