### PR TITLE
Utilize search score if previous score unknown

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230226
+VERSION  = 20230226b
 MAIN_NETWORK = networks/berserk-e3f526b26f50.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -268,6 +268,11 @@ void Search(ThreadData* thread) {
 
       Score searchScoreDiff    = scores[thread->depth - 3] - bestScore;
       Score prevScoreDiff      = thread->previousScore - bestScore;
+
+      // if we don't know the previous score, work only on the searchscore
+      if (thread->previousScore == UNKNOWN)
+        searchScoreDiff *= 2, prevScoreDiff = 0; 
+
       double scoreChangeFactor = 0.1 +                                              //
                                  0.0275 * searchScoreDiff * (searchScoreDiff > 0) + //
                                  0.0275 * prevScoreDiff * (prevScoreDiff > 0);


### PR DESCRIPTION
Bench: 4126688

This patch is really for STC games where the first move has a long delay for no reason. This will most likely be neutral at LTC.

**STC**
```
ELO   | 5.73 +- 3.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 16496 W: 3922 L: 3650 D: 8924
```