### PR TITLE
Singular Extension Tweaks

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230227
+VERSION  = 20230304
 MAIN_NETWORK = networks/berserk-e3f526b26f50.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -596,7 +596,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (depth >= 7 && move == hashMove && TTDepth(tt) >= depth - 3 && (TTBound(tt) & BOUND_LOWER) &&
           abs(ttScore) < WINNING_ENDGAME) {
         int sBeta  = Max(ttScore - depth, -CHECKMATE);
-        int sDepth = depth / 2 - 1;
+        int sDepth = (depth - 1) / 2;
 
         ss->skip = move;
         score    = Negamax(sBeta - 1, sBeta, sDepth, cutnode, thread, pv, ss);

--- a/src/search.c
+++ b/src/search.c
@@ -595,8 +595,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // ttHit is implied for move == hashMove to ever be true
       if (depth >= 7 && move == hashMove && TTDepth(tt) >= depth - 3 && (TTBound(tt) & BOUND_LOWER) &&
           abs(ttScore) < WINNING_ENDGAME) {
-        int sBeta  = Max(ttScore - 3 * depth / 2, -CHECKMATE);
-        int sDepth = (depth - 1) / 2;
+        int sBeta  = Max(ttScore - depth, -CHECKMATE);
+        int sDepth = depth / 2 - 1;
 
         ss->skip = move;
         score    = Negamax(sBeta - 1, sBeta, sDepth, cutnode, thread, pv, ss);

--- a/src/search.c
+++ b/src/search.c
@@ -596,7 +596,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (depth >= 7 && move == hashMove && TTDepth(tt) >= depth - 3 && (TTBound(tt) & BOUND_LOWER) &&
           abs(ttScore) < WINNING_ENDGAME) {
         int sBeta  = Max(ttScore - 3 * depth / 2, -CHECKMATE);
-        int sDepth = depth / 2 - 1;
+        int sDepth = (depth - 1) / 2;
 
         ss->skip = move;
         score    = Negamax(sBeta - 1, sBeta, sDepth, cutnode, thread, pv, ss);


### PR DESCRIPTION
Bench: 4921437

**STC**
```
ELO   | -0.06 +- 1.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 68568 W: 15969 L: 15980 D: 36619
```

**LTC**
```
ELO   | 3.23 +- 2.42 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 34624 W: 7744 L: 7422 D: 19458
```