### PR TITLE
Increase hash size

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230310
+VERSION  = 20230310b
 MAIN_NETWORK = networks/berserk-39d459a3f88e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -99,7 +99,7 @@ inline void TTPrefetch(uint64_t hash) {
 
 inline TTEntry* TTProbe(uint64_t hash, int* hit) {
   TTEntry* bucket    = TT.buckets[TTIdx(hash)].entries;
-  uint16_t shortHash = (uint16_t) hash;
+  uint32_t shortHash = (uint32_t) hash;
 
   for (int i = 0; i < BUCKET_SIZE; i++) {
     if (bucket[i].hash == shortHash || !bucket[i].depth) {
@@ -122,7 +122,7 @@ inline TTEntry* TTProbe(uint64_t hash, int* hit) {
 
 inline void
 TTPut(TTEntry* tt, uint64_t hash, int depth, int16_t score, uint8_t bound, Move move, int ply, int16_t eval, int pv) {
-  uint16_t shortHash = (uint16_t) hash;
+  uint32_t shortHash = (uint32_t) hash;
 
   if (score >= TB_WIN_BOUND)
     score += ply;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -22,7 +22,7 @@
 
 #define NO_ENTRY    0ULL
 #define MEGABYTE    (1024ull * 1024ull)
-#define BUCKET_SIZE 5
+#define BUCKET_SIZE 2
 
 #define BOUND_MASK (0x3)
 #define PV_MASK    (0x4)
@@ -31,7 +31,7 @@
 #define AGE_CYCLE  (255 + AGE_INC)
 
 typedef struct {
-  uint16_t hash;
+  uint32_t hash;
   uint8_t depth, agePvBound;
   Move move;
   int16_t score, eval;
@@ -39,7 +39,6 @@ typedef struct {
 
 typedef struct {
   TTEntry entries[BUCKET_SIZE];
-  uint32_t padding;
 } TTBucket;
 
 typedef struct {


### PR DESCRIPTION
Bench: 5275334

**STC**
```
ELO   | 0.85 +- 1.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -0.86 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 96072 W: 22798 L: 22564 D: 50710
```

**LTC**
```
ELO   | -1.33 +- 3.64 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -1.43 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 15624 W: 3466 L: 3526 D: 8632
```

**SMP**
```
ELO   | 1.91 +- 1.52 (95%)
SPRT  | 4.0+0.04s Threads=8 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 93713 W: 22250 L: 21736 D: 49727
```