### PR TITLE
Almost always negative extension when SE fails

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230311
+VERSION  = 20230317
 MAIN_NETWORK = networks/berserk-39d459a3f88e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -610,6 +610,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
           return sBeta;
         else if (ttScore >= beta)
           extension = -1;
+        else if (ttScore <= alpha)
+          extension = -1;
       }
 
       // re-capture extension - looks for a follow up capture on the same square


### PR DESCRIPTION
Bench: 5178143

**STC**
```
ELO   | 3.96 +- 2.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 27264 W: 6602 L: 6291 D: 14371
```

**LTC**
```
ELO   | 4.64 +- 3.11 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 21288 W: 4874 L: 4590 D: 11824
```