### PR TITLE
Scale eval on FMR

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230317
+VERSION  = 20230321
 MAIN_NETWORK = networks/berserk-39d459a3f88e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -80,7 +80,7 @@ INLINE int CheckLimits(ThreadData* thread) {
 }
 
 INLINE int AdjustEvalOnFMR(Board* board, int eval) {
-  return board->fmr > 16 ? (144 - board->fmr) * eval / 128 : eval;
+  return (200 - board->fmr) * eval / 200;
 }
 
 void StartSearch(Board* board, uint8_t ponder) {

--- a/src/search.c
+++ b/src/search.c
@@ -413,10 +413,16 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (ss->staticEval == UNKNOWN)
         eval = ss->staticEval = Evaluate(board, thread);
 
+      // correct eval on fmr
+      eval = (200 - board->fmr) * eval / 200;
+
       if (ttScore != UNKNOWN && (TTBound(tt) & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
         eval = ttScore;
     } else if (!ss->skip) {
       eval = ss->staticEval = Evaluate(board, thread);
+
+      // correct eval on fmr
+      eval = (200 - board->fmr) * eval / 200;
 
       TTPut(tt, board->zobrist, -1, UNKNOWN, BOUND_UNKNOWN, NULL_MOVE, ss->ply, ss->staticEval, ttPv);
     }
@@ -799,10 +805,15 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
       if (ss->staticEval == UNKNOWN)
         eval = ss->staticEval = Evaluate(board, thread);
 
+      // correct eval on fmr
+      eval = (200 - board->fmr) * eval / 200;
+
       if (ttScore != UNKNOWN && (TTBound(tt) & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
         eval = ttScore;
     } else {
       eval = ss->staticEval = Evaluate(board, thread);
+      // correct eval on fmr
+      eval = (200 - board->fmr) * eval / 200;
 
       TTPut(tt, board->zobrist, -1, UNKNOWN, BOUND_UNKNOWN, NULL_MOVE, ss->ply, ss->staticEval, ttPv);
     }

--- a/src/search.c
+++ b/src/search.c
@@ -79,6 +79,10 @@ INLINE int CheckLimits(ThreadData* thread) {
          (Limits.nodes && NodesSearched() >= Limits.nodes);
 }
 
+INLINE int AdjustEvalOnFMR(Board* board, int eval) {
+  return board->fmr > 16 ? (144 - board->fmr) * eval / 128 : eval;
+}
+
 void StartSearch(Board* board, uint8_t ponder) {
   if (Threads.searching)
     ThreadWaitUntilSleep(Threads.threads[0]);
@@ -414,7 +418,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         eval = ss->staticEval = Evaluate(board, thread);
 
       // correct eval on fmr
-      eval = (200 - board->fmr) * eval / 200;
+      eval = AdjustEvalOnFMR(board, eval);
 
       if (ttScore != UNKNOWN && (TTBound(tt) & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
         eval = ttScore;
@@ -422,7 +426,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       eval = ss->staticEval = Evaluate(board, thread);
 
       // correct eval on fmr
-      eval = (200 - board->fmr) * eval / 200;
+      eval = AdjustEvalOnFMR(board, eval);
 
       TTPut(tt, board->zobrist, -1, UNKNOWN, BOUND_UNKNOWN, NULL_MOVE, ss->ply, ss->staticEval, ttPv);
     }
@@ -806,14 +810,14 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
         eval = ss->staticEval = Evaluate(board, thread);
 
       // correct eval on fmr
-      eval = (200 - board->fmr) * eval / 200;
+      eval = AdjustEvalOnFMR(board, eval);
 
       if (ttScore != UNKNOWN && (TTBound(tt) & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
         eval = ttScore;
     } else {
       eval = ss->staticEval = Evaluate(board, thread);
       // correct eval on fmr
-      eval = (200 - board->fmr) * eval / 200;
+      eval = AdjustEvalOnFMR(board, eval);
 
       TTPut(tt, board->zobrist, -1, UNKNOWN, BOUND_UNKNOWN, NULL_MOVE, ss->ply, ss->staticEval, ttPv);
     }


### PR DESCRIPTION
Bench: 4555521

**STC** - http://chess.grantnet.us/test/31692/
```
ELO   | 1.98 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 87056 W: 20810 L: 20315 D: 45931
```

**LTC** - http://chess.grantnet.us/test/31702/
```
ELO   | 1.45 +- 1.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 188928 W: 42553 L: 41767 D: 104608
```