### PR TITLE
Fix Black QS castle in FRC

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -602,7 +602,7 @@ int IsPseudoLegal(Move move, Board* board) {
         if (GetBit(board->pinned, board->cr[3]))
           return 0;
         BitBoard between = BetweenSquares(kingsq, C8) | BetweenSquares(board->cr[3], D8) | Bit(C8) | Bit(D8);
-        if ((OccBB(BOTH) ^ PieceBB(KING, WHITE) ^ Bit(board->cr[3])) & between)
+        if ((OccBB(BOTH) ^ PieceBB(KING, BLACK) ^ Bit(board->cr[3])) & between)
           return 0;
         break;
       }

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230328
+VERSION  = 20230605
 MAIN_NETWORK = networks/berserk-39d459a3f88e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/move.c
+++ b/src/move.c
@@ -72,9 +72,16 @@ Move ParseMove(char* moveStr, Board* board) {
   SimpleMoveList rootMoves;
   RootMoves(&rootMoves, board);
 
-  for (int i = 0; i < rootMoves.count; i++)
-    if (!strcmp(MoveToStr(rootMoves.moves[i], board), moveStr))
+  for (int i = 0; i < rootMoves.count; i++) {
+    if (!strcmp("O-O", moveStr) && IsCas(rootMoves.moves[i]) &&
+        To(rootMoves.moves[i]) == (board->stm == WHITE ? G1 : G8))
       return rootMoves.moves[i];
+    else if (!strcmp("O-O-O", moveStr) && IsCas(rootMoves.moves[i]) &&
+             To(rootMoves.moves[i]) == (board->stm == WHITE ? C1 : C8))
+      return rootMoves.moves[i];
+    else if (!strcmp(MoveToStr(rootMoves.moves[i], board), moveStr))
+      return rootMoves.moves[i];
+  }
 
   return NULL_MOVE;
 }


### PR DESCRIPTION
Bench: 4555521

Fixes an issue where if a black qs castle move was a hashmove or killer, it would be filtered due to not being pseudo legal. Also support input of `O-O` and `O-O-O` for castle moves.

```
ELO   | 6.08 +- 4.31 (95%)
CONF  | 8.0+0.08s Threads=1 Hash=8MB
GAMES | N: 10000 W: 2095 L: 1920 D: 5985
http://chess.grantnet.us/test/32242/
```