### PR TITLE
Remove inline ASM

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230607
+VERSION  = 20230710
 MAIN_NETWORK = networks/berserk-39d459a3f88e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/nn/evaluate.c
+++ b/src/nn/evaluate.c
@@ -94,19 +94,8 @@ INLINE void m256_add_dpbusd_epi32x4(__m256i* acc, const __m256i* inputs, const _
   __m256i tmp2 = _mm256_maddubs_epi16(inputs[2], weights[2]);
   __m256i tmp3 = _mm256_maddubs_epi16(inputs[3], weights[3]);
 
-#if (defined(__GNUC__) && !defined(__clang__))
-  asm(
-    "vpaddsw     %[tmp0], %[tmp1], %[tmp0]\n\t"
-    "vpaddsw     %[tmp0], %[tmp2], %[tmp0]\n\t"
-    "vpaddsw     %[tmp0], %[tmp3], %[tmp0]\n\t"
-    "vpmaddwd    %[tmp0], %[ones], %[tmp0]\n\t"
-    "vpaddd      %[acc], %[tmp0], %[acc]"
-    : [acc] "+v"(*acc), [tmp0] "+&v"(tmp0)
-    : [tmp1] "v"(tmp1), [tmp2] "v"(tmp2), [tmp3] "v"(tmp3), [ones] "v"(_mm256_set1_epi16(1)));
-#else
   tmp0 = _mm256_add_epi16(tmp0, _mm256_add_epi16(tmp1, _mm256_add_epi16(tmp2, tmp3)));
   *acc = _mm256_add_epi32(*acc, _mm256_madd_epi16(tmp0, _mm256_set1_epi16(1)));
-#endif
 }
 
 INLINE void m256_hadd_epi32x4(__m256i* regs) {
@@ -153,19 +142,8 @@ INLINE void m128_add_dpbusd_epi32x4(__m128i* acc, const __m128i* inputs, const _
   __m128i tmp2 = _mm_maddubs_epi16(inputs[2], weights[2]);
   __m128i tmp3 = _mm_maddubs_epi16(inputs[3], weights[3]);
 
-#if (defined(__GNUC__) && !defined(__clang__))
-  asm(
-    "paddsw     %[tmp1], %[tmp0]\n\t"
-    "paddsw     %[tmp2], %[tmp0]\n\t"
-    "paddsw     %[tmp3], %[tmp0]\n\t"
-    "pmaddwd    %[ones], %[tmp0]\n\t"
-    "paddd      %[tmp0], %[acc]"
-    : [acc] "+v"(*acc), [tmp0] "+&v"(tmp0)
-    : [tmp1] "v"(tmp1), [tmp2] "v"(tmp2), [tmp3] "v"(tmp3), [ones] "v"(_mm_set1_epi16(1)));
-#else
   tmp0 = _mm_add_epi16(tmp0, _mm_add_epi16(tmp1, _mm_add_epi16(tmp2, tmp3)));
   *acc = _mm_add_epi32(*acc, _mm_madd_epi16(tmp0, _mm_set1_epi16(1)));
-#endif
 }
 
 INLINE void m128_hadd_epi32x4(__m128i* regs) {


### PR DESCRIPTION
Bench: 4574524

ELO   | 4.79 +- 4.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 10664 W: 2623 L: 2476 D: 5565
http://chess.grantnet.us/test/32724/