### PR TITLE
Skip quiet moves once checkmate avoided in QSearch

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230811
+VERSION  = 20230813
 MAIN_NETWORK = networks/berserk-7dc28215434e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -835,9 +835,13 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
 
     legalMoves++;
 
-    // if we're in check, final condition in SEE always 0
-    if (bestScore > -TB_WIN_BOUND && !SEE(board, move, eval <= alpha - DELTA_CUTOFF))
-      continue;
+    if (bestScore > -TB_WIN_BOUND) {
+      if (!(IsCap(move) || Promo(move)))
+        break;
+
+      if (!SEE(board, move, eval <= alpha - DELTA_CUTOFF))
+        continue;
+    }
 
     TTPrefetch(KeyAfter(board, move));
     ss->move = move;


### PR DESCRIPTION
Bench: 4723542

ELO   | 2.47 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 56624 W: 13628 L: 13226 D: 29770
http://chess.grantnet.us/test/33144/

ELO   | 6.97 +- 4.01 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 12856 W: 2997 L: 2739 D: 7120
http://chess.grantnet.us/test/33149/