### PR TITLE
Multiple changes

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -45,6 +45,8 @@ INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
     AddHistoryHeuristic(&(*(ss - 2)->ch)[Moving(move)][To(move)], bonus);
   if ((ss - 4)->move)
     AddHistoryHeuristic(&(*(ss - 4)->ch)[Moving(move)][To(move)], bonus);
+  if ((ss - 6)->move)
+    AddHistoryHeuristic(&(*(ss - 6)->ch)[Moving(move)][To(move)], bonus);
 }
 
 void UpdateHistories(SearchStack* ss,

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -51,10 +51,10 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
     Move move = current->move;
 
     if (type == ST_QUIET)
-      current->score = (int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
-                       (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
-                       (int) (*(ss - 2)->ch)[Moving(move)][To(move)] +        //
-                       (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +        //
+      current->score = 2 * ((int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
+                            (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
+                            (int) (*(ss - 2)->ch)[Moving(move)][To(move)]) +       //
+                       (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +             //
                        (int) (*(ss - 6)->ch)[Moving(move)][To(move)];
 
     else if (type == ST_CAPTURE)
@@ -64,10 +64,10 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
       if (IsCap(move))
         current->score = 1e7 + SEE_VALUE[IsEP(move) ? PAWN : PieceType(board->squares[To(move)])];
       else
-        current->score = (int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
-                         (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
-                         (int) (*(ss - 2)->ch)[Moving(move)][To(move)] +        //
-                         (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +        //
+        current->score = 2 * ((int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
+                              (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
+                              (int) (*(ss - 2)->ch)[Moving(move)][To(move)]) +       //
+                         (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +             //
                          (int) (*(ss - 6)->ch)[Moving(move)][To(move)];
     }
 

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -51,12 +51,25 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
     Move move = current->move;
 
     if (type == ST_QUIET)
-      current->score = GetQuietHistory(picker->ss, picker->thread, move);
+      current->score = (int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
+                       (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
+                       (int) (*(ss - 2)->ch)[Moving(move)][To(move)] +        //
+                       (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +        //
+                       (int) (*(ss - 6)->ch)[Moving(move)][To(move)];
+
     else if (type == ST_CAPTURE)
       current->score = GetCaptureHistory(picker->thread, move) / 16 + SEE_VALUE[PieceType(board->squares[To(move)])];
-    else if (type == ST_EVASION)
-      current->score = IsCap(move) ? 1e7 + SEE_VALUE[IsEP(move) ? PAWN : PieceType(board->squares[To(move)])] :
-                                     GetQuietHistory(ss, thread, move);
+
+    else if (type == ST_EVASION) {
+      if (IsCap(move))
+        current->score = 1e7 + SEE_VALUE[IsEP(move) ? PAWN : PieceType(board->squares[To(move)])];
+      else
+        current->score = (int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
+                         (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
+                         (int) (*(ss - 2)->ch)[Moving(move)][To(move)] +        //
+                         (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +        //
+                         (int) (*(ss - 6)->ch)[Moving(move)][To(move)];
+    }
 
     current++;
   }

--- a/src/search.c
+++ b/src/search.c
@@ -165,12 +165,12 @@ void Search(ThreadData* thread) {
   int searchStability   = 0;
   Move previousBestMove = NULL_MOVE;
 
-  SearchStack searchStack[MAX_SEARCH_PLY + 4];
-  SearchStack* ss = searchStack + 4;
+  SearchStack searchStack[MAX_SEARCH_PLY + 6];
+  SearchStack* ss = searchStack + 6;
   memset(searchStack, 0, 5 * sizeof(SearchStack));
   for (size_t i = 0; i < MAX_SEARCH_PLY; i++)
     (ss + i)->ply = i;
-  for (size_t i = 1; i <= 4; i++)
+  for (size_t i = 1; i <= 6; i++)
     (ss - i)->ch = &thread->ch[0][WHITE_PAWN][A1];
 
   while (++thread->depth < MAX_SEARCH_PLY) {

--- a/src/search.c
+++ b/src/search.c
@@ -363,7 +363,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
   // if the TT has a value that fits our position and has been searched to an
   // equal or greater depth, then we accept this score and prune
-  if (!isPV && ttScore != UNKNOWN && TTDepth(tt) >= depth &&
+  if (!isPV && ttScore != UNKNOWN && TTDepth(tt) >= depth && (cutnode || ttScore <= alpha) &&
       (TTBound(tt) & (ttScore >= beta ? BOUND_LOWER : BOUND_UPPER)))
     return ttScore;
 
@@ -460,12 +460,13 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   if (!isPV && !inCheck) {
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
-    if (depth <= 9 && !ss->skip && eval < WINNING_ENDGAME &&
-        eval - 75 * depth + 100 * (improving && !oppThreatPcs) >= beta && eval >= beta)
+    if (depth <= 8 && !ss->skip && eval < WINNING_ENDGAME && eval >= beta &&
+        eval - 69 * depth + 112 * (improving && !oppThreatPcs) >= beta &&
+        (!hashMove || GetHistory(ss, thread, hashMove) > 12288))
       return eval;
 
     // Razoring
-    if (depth <= 5 && eval + 200 * depth <= alpha) {
+    if (depth <= 6 && eval + 250 * depth <= alpha) {
       score = Quiesce(alpha, beta, thread, ss);
       if (score <= alpha)
         return score;
@@ -478,7 +479,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     if (depth >= 3 && (ss - 1)->move != NULL_MOVE && !ss->skip && eval >= beta &&
         // weiss conditional
         HasNonPawn(board) > (depth > 12)) {
-      int R = 4 + depth / 6 + Min((eval - beta) / 256, 3) + !oppThreatPcs;
+      int R = 4 + 188 * depth / 1024 + Min(5 * (eval - beta) / 1024, 3) + !oppThreatPcs;
       R     = Min(depth, R); // don't go too low
 
       TTPrefetch(KeyAfter(board, NULL_MOVE));
@@ -498,8 +499,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // If a relatively deep search from our TT doesn't say this node is
     // less than beta + margin, then we run a shallow search to look
     Threats(&ss->ownThreat, board, board->stm);
-    int probBeta = beta + 110 - 30 * improving;
-    if (depth > 4 && abs(beta) < TB_WIN_BOUND && ss->ownThreat.pcs &&
+    int probBeta = beta + 111 - 26 * improving;
+    if (depth > 6 && abs(beta) < TB_WIN_BOUND && ss->ownThreat.pcs &&
         !(tt && TTDepth(tt) >= depth - 3 && ttScore < probBeta)) {
       InitPCMovePicker(&mp, thread);
       while ((move = NextMove(&mp, board, 1))) {
@@ -559,12 +560,12 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (!IsCap(move) && PieceType(Promo(move)) != QUEEN) {
         int lmrDepth = Max(1, depth - LMR[Min(depth, 63)][Min(legalMoves, 63)]);
 
-        if (!killerOrCounter && lmrDepth < 6 && history < -4096 * (depth - 1)) {
+        if (!killerOrCounter && lmrDepth < 6 && history < -2500 * (depth - 1)) {
           skipQuiets = 1;
           continue;
         }
 
-        if (lmrDepth < 9 && eval + 100 + 50 * lmrDepth + history / 128 <= alpha)
+        if (lmrDepth < 10 && eval + 88 + 47 * lmrDepth + 13 * history / 2048 <= alpha)
           skipQuiets = 1;
 
         if (!SEE(board, move, STATIC_PRUNE[0][lmrDepth]))
@@ -598,7 +599,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // ttHit is implied for move == hashMove to ever be true
       if (depth >= 7 && move == hashMove && TTDepth(tt) >= depth - 3 && (TTBound(tt) & BOUND_LOWER) &&
           abs(ttScore) < WINNING_ENDGAME) {
-        int sBeta  = Max(ttScore - depth, -CHECKMATE);
+        int sBeta  = Max(ttScore - 5 * depth / 8, -CHECKMATE);
         int sDepth = (depth - 1) / 2;
 
         ss->skip = move;
@@ -607,7 +608,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
         // no score failed above sBeta, so this is singular
         if (score < sBeta) {
-          if (!isPV && score < sBeta - 20 && ss->de <= 6) {
+          if (!isPV && score < sBeta - 18 && ss->de <= 6) {
             extension = 2;
             ss->de    = (ss - 1)->de + 1;
           } else {
@@ -616,7 +617,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         } else if (sBeta >= beta)
           return sBeta;
         else if (ttScore >= beta)
-          extension = -1;
+          extension = -2 + isPV;
         else if (ttScore <= alpha)
           extension = -1;
       }
@@ -638,7 +639,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     int doFullSearch = 0;
 
     // Late move reductions
-    if (depth > 2 && legalMoves > 1 && !(ttPv && IsCap(move))) {
+    if (depth > 2 && legalMoves > 1 && !(isPV && IsCap(move))) {
       int R = LMR[Min(depth, 63)][Min(legalMoves, 63)];
 
       // increase reduction on non-pv
@@ -654,7 +655,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         R -= 2;
 
       // less likely a non-capture is best
-      if (IsCap(hashMove))
+      if (IsCap(hashMove) || Promo(hashMove))
         R++;
 
       // move GAVE check
@@ -669,7 +670,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         R += 1 + !IsCap(move);
 
       // adjust reduction based on historical score
-      R -= history / 8192;
+      R -= 9 * history / 65536;
 
       // prevent dropping into QS, extending, or reducing all extensions
       R = Min(depth - 1, Max(R, 1));
@@ -727,7 +728,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       // we're failing high
       if (alpha >= beta) {
-        UpdateHistories(ss, thread, move, depth + (bestScore > beta + 100), quiets, numQuiets, captures, numCaptures);
+        UpdateHistories(ss, thread, move, depth + (bestScore > beta + 86), quiets, numQuiets, captures, numCaptures);
         break;
       }
     }
@@ -753,6 +754,7 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
   Board* board = &thread->board;
 
   int score     = -CHECKMATE;
+  int futility  = -CHECKMATE;
   int bestScore = -CHECKMATE + ss->ply;
   int isPV      = beta - alpha != 1;
   int ttHit     = 0;
@@ -817,6 +819,8 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
       alpha = eval;
 
     bestScore = eval;
+
+    futility = bestScore + DELTA_CUTOFF;
   }
 
   if (!inCheck)
@@ -839,7 +843,12 @@ int Quiesce(int alpha, int beta, ThreadData* thread, SearchStack* ss) {
       if (!(IsCap(move) || Promo(move)))
         break;
 
-      if (!SEE(board, move, eval <= alpha - DELTA_CUTOFF))
+      if (!inCheck && futility <= alpha && !SEE(board, move, 1)) {
+        bestScore = Max(bestScore, futility);
+        continue;
+      }
+
+      if (!SEE(board, move, 0))
         continue;
     }
 

--- a/src/search.h
+++ b/src/search.h
@@ -29,13 +29,11 @@
 #define TB_WIN_BOUND (TB_WIN_SCORE - MAX_SEARCH_PLY)
 
 // static evaluation pruning
-// capture cutoff is linear 70x
-// quiet cutoff is quadratic 20x^2
-#define SEE_PRUNE_CAPTURE_CUTOFF 90
-#define SEE_PRUNE_CUTOFF         15
+#define SEE_PRUNE_CAPTURE_CUTOFF 104
+#define SEE_PRUNE_CUTOFF         17
 
 // delta pruning in QS
-#define DELTA_CUTOFF 50
+#define DELTA_CUTOFF 55
 
 // base window value
 #define WINDOW 10

--- a/src/types.h
+++ b/src/types.h
@@ -22,7 +22,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 
-#define MAX_SEARCH_PLY 251 // effective max depth 250
+#define MAX_SEARCH_PLY 201 // effective max depth 250
 #define MAX_MOVES      128
 
 #define N_KING_BUCKETS 16


### PR DESCRIPTION
Bench: 5115048

This patch merges many yellow patches + SPSA tuning.
- Additional continuation history for move picker ordering
- Adjust history ratios in move picker ordering
- Only accept beta cutoffs on cutnodes
- SPSA tune @ 12k iterations (60+0.6)
- More negative extensions
- LMR on captures on ttpv nodes
- QS futility values

ELO   | 8.62 +- 4.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 10160 W: 2444 L: 2192 D: 5524
http://chess.grantnet.us/test/33198/