### PR TITLE
Force no counter move after null move

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -34,7 +34,10 @@ INLINE void InitNormalMovePicker(MovePicker* picker, Move hashMove, ThreadData* 
   picker->hashMove = hashMove;
   picker->killer1  = ss->killers[0];
   picker->killer2  = ss->killers[1];
-  picker->counter  = thread->counters[Moving((ss - 1)->move)][To((ss - 1)->move)];
+  if ((ss - 1)->move)
+    picker->counter  = thread->counters[Moving((ss - 1)->move)][To((ss - 1)->move)];
+  else
+    picker->counter = NULL_MOVE;
 
   picker->thread = thread;
   picker->ss     = ss;


### PR DESCRIPTION
Bench: 5803982

ELO   | 1.63 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-2.50, 0.50]
GAMES | N: 33120 W: 7977 L: 7822 D: 17321
http://chess.grantnet.us/test/33273/

ELO   | -0.28 +- 1.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.43 (-2.94, 2.94) [-2.50, 0.50]
GAMES | N: 149160 W: 34118 L: 34239 D: 80803
http://chess.grantnet.us/test/33274/