### PR TITLE
Increase reduction amount on non-pv nodes

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230827
+VERSION  = 20230902
 MAIN_NETWORK = networks/berserk-7dc28215434e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -643,7 +643,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       // increase reduction on non-pv
       if (!ttPv)
-        R++;
+        R += 2;
 
       // increase reduction if our eval is declining
       if (!improving)


### PR DESCRIPTION
Bench: 4466149

ELO   | 1.81 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 109728 W: 26548 L: 25976 D: 57204
http://chess.grantnet.us/test/33454/

ELO   | 3.84 +- 2.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 27712 W: 6468 L: 6162 D: 15082
http://chess.grantnet.us/test/33462/