### PR TITLE
Update network to berserk-c9bf061efa4d.nn

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,8 +4,8 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230905
-MAIN_NETWORK = networks/berserk-7dc28215434e.nn
+VERSION  = 20230906
+MAIN_NETWORK = networks/berserk-c9bf061efa4d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG
 

--- a/src/nn/accumulator.h
+++ b/src/nn/accumulator.h
@@ -24,8 +24,8 @@
 #include "../util.h"
 
 #if defined(__AVX512F__)
-#define UNROLL     256
-#define NUM_REGS   8
+#define UNROLL     512
+#define NUM_REGS   16
 #define regi_t     __m512i
 #define regi_load  _mm512_load_si512
 #define regi_sub   _mm512_sub_epi16

--- a/src/nn/evaluate.h
+++ b/src/nn/evaluate.h
@@ -19,6 +19,8 @@
 
 #include "../types.h"
 
+#define SPARSE_CHUNK_SIZE 4
+
 int Predict(Board* board);
 int Propagate(Accumulator* accumulator, const int stm);
 

--- a/src/types.h
+++ b/src/types.h
@@ -31,7 +31,7 @@
 #define N_FEATURES (N_KING_BUCKETS * 12 * 64)
 #define N_HIDDEN   768
 #define N_L1       (2 * N_HIDDEN)
-#define N_L2       8
+#define N_L2       16
 #define N_L3       32
 #define N_OUTPUT   1
 

--- a/src/types.h
+++ b/src/types.h
@@ -29,7 +29,7 @@
 #define N_KING_BUCKETS 16
 
 #define N_FEATURES (N_KING_BUCKETS * 12 * 64)
-#define N_HIDDEN   768
+#define N_HIDDEN   1024
 #define N_L1       (2 * N_HIDDEN)
 #define N_L2       16
 #define N_L3       32


### PR DESCRIPTION
Bench: 4886939

This is an arch change for Berserk which increases the network size by ~33%. The new layout is (2x1024)->16->32->1. In order to use such a large FT, Berserk now relies on sparse matrix multiplication after the FT. Further optimizations will be made to this network as it remains unsorted and sparsity untouched outside the defaults.

This is the first network in Berserk trained by [Grapheus](https://github.com/Luecx/Grapheus). 

ELO   | -0.21 +- 5.17 (95%)
CONF  | 8.0+0.08s Threads=1 Hash=8MB
GAMES | N: 8384 W: 2028 L: 2033 D: 4323
http://chess.grantnet.us/test/33528/

ELO   | 6.39 +- 3.82 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 14512 W: 3447 L: 3180 D: 7885
http://chess.grantnet.us/test/33529/