### PR TITLE
Calculate threats for every MakeMove

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -704,7 +704,7 @@ int IsPseudoLegal(Move move, Board* board) {
 }
 
 // this is NOT a legality checker for ALL moves
-// it is only used by move generation for king moves, castles, and ep captures
+// it is only used for final verification of EP and pinned moves.
 int IsLegal(Move move, Board* board) {
   int from   = From(move);
   int to     = To(move);

--- a/src/board.c
+++ b/src/board.c
@@ -282,6 +282,9 @@ inline void SetThreatsAndEasyCaptures(Board* board) {
 
   board->threatened = board->easyCapture = 0;
 
+  // Take the enemy king off for through threats.
+  BitBoard occ = OccBB(BOTH) ^ PieceBB(KING, xstm);
+
   BitBoard opponentPieces = OccBB(xstm) ^ PieceBB(PAWN, xstm);
 
   BitBoard pawnAttacks = stm == WHITE ? ShiftNW(PieceBB(PAWN, WHITE)) | ShiftNE(PieceBB(PAWN, WHITE)) :
@@ -302,7 +305,7 @@ inline void SetThreatsAndEasyCaptures(Board* board) {
 
   BitBoard bishops = PieceBB(BISHOP, stm);
   while (bishops) {
-    BitBoard atx = GetBishopAttacks(PopLSB(&bishops), OccBB(BOTH));
+    BitBoard atx = GetBishopAttacks(PopLSB(&bishops), occ);
 
     board->threatened |= atx;
     board->easyCapture |= opponentPieces & atx;
@@ -313,7 +316,7 @@ inline void SetThreatsAndEasyCaptures(Board* board) {
 
   BitBoard rooks = PieceBB(ROOK, stm);
   while (rooks) {
-    BitBoard atx = GetRookAttacks(PopLSB(&rooks), OccBB(BOTH));
+    BitBoard atx = GetRookAttacks(PopLSB(&rooks), occ);
 
     board->threatened |= atx;
     board->easyCapture |= opponentPieces & atx;
@@ -321,7 +324,7 @@ inline void SetThreatsAndEasyCaptures(Board* board) {
 
   BitBoard queens = PieceBB(QUEEN, stm);
   while (queens)
-    board->threatened |= GetQueenAttacks(PopLSB(&queens), OccBB(BOTH));
+    board->threatened |= GetQueenAttacks(PopLSB(&queens), occ);
 
   board->threatened |= GetKingAttacks(LSB(PieceBB(KING, stm)));
 }
@@ -625,50 +628,21 @@ int IsPseudoLegal(Move move, Board* board) {
     if (board->checkers || !board->castling)
       return 0;
 
-    int kingsq = LSB(PieceBB(KING, board->stm));
+    int idx = 2 * board->stm + (File(to) != 6); // 0 = G1, 1 = C1, 2 = G8, 3 = C8
+    if (!CanCastle(CASTLE_MAP[idx][0]))
+      return 0;
+    if (GetBit(board->pinned, board->cr[idx]))
+      return 0;
 
-    switch (to) {
-      case G1: {
-        if (!CanCastle(WHITE_KS))
-          return 0;
-        if (GetBit(board->pinned, board->cr[0]))
-          return 0;
-        BitBoard between = BetweenSquares(kingsq, G1) | BetweenSquares(board->cr[0], F1) | Bit(G1) | Bit(F1);
-        if ((OccBB(BOTH) ^ PieceBB(KING, WHITE) ^ Bit(board->cr[0])) & between)
-          return 0;
-        break;
-      }
-      case C1: {
-        if (!CanCastle(WHITE_QS))
-          return 0;
-        if (GetBit(board->pinned, board->cr[1]))
-          return 0;
-        BitBoard between = BetweenSquares(kingsq, C1) | BetweenSquares(board->cr[1], D1) | Bit(C1) | Bit(D1);
-        if ((OccBB(BOTH) ^ PieceBB(KING, WHITE) ^ Bit(board->cr[1])) & between)
-          return 0;
-        break;
-      }
-      case G8: {
-        if (!CanCastle(BLACK_KS))
-          return 0;
-        if (GetBit(board->pinned, board->cr[2]))
-          return 0;
-        BitBoard between = BetweenSquares(kingsq, G8) | BetweenSquares(board->cr[2], F8) | Bit(G8) | Bit(F8);
-        if ((OccBB(BOTH) ^ PieceBB(KING, BLACK) ^ Bit(board->cr[2])) & between)
-          return 0;
-        break;
-      }
-      case C8: {
-        if (!CanCastle(BLACK_QS))
-          return 0;
-        if (GetBit(board->pinned, board->cr[3]))
-          return 0;
-        BitBoard between = BetweenSquares(kingsq, C8) | BetweenSquares(board->cr[3], D8) | Bit(C8) | Bit(D8);
-        if ((OccBB(BOTH) ^ PieceBB(KING, BLACK) ^ Bit(board->cr[3])) & between)
-          return 0;
-        break;
-      }
-    }
+    int rookTo            = CASTLE_MAP[idx][2];
+    BitBoard kingCrossing = BetweenSquares(from, to) | Bit(to);
+    BitBoard rookCrossing = BetweenSquares(board->cr[idx], rookTo) | Bit(rookTo);
+    BitBoard between      = kingCrossing | rookCrossing;
+
+    if ((OccBB(BOTH) ^ Bit(from) ^ Bit(board->cr[idx])) & between)
+      return 0;
+    if (kingCrossing & board->threatened)
+      return 0;
 
     return 1;
   }
@@ -693,6 +667,8 @@ int IsPseudoLegal(Move move, Board* board) {
   if (IsEP(move) && to != board->epSquare)
     return 0;
   if (GetBit(OccBB(board->stm), to))
+    return 0;
+  if (pcType == KING && GetBit(board->threatened, to))
     return 0;
 
   if (pcType == PAWN) {
@@ -742,21 +718,6 @@ int IsLegal(Move move, Board* board) {
     return !(GetBishopAttacks(kingSq, occ) & (PieceBB(BISHOP, board->xstm) | PieceBB(QUEEN, board->xstm))) &&
            !(GetRookAttacks(kingSq, occ) & (PieceBB(ROOK, board->xstm) | PieceBB(QUEEN, board->xstm)));
   }
-
-  if (IsCas(move)) {
-    int step = to > from ? -1 : 1;
-
-    // pieces in-between have been checked, now check that it's not castling
-    // through or into check
-    for (int i = to; i != from; i += step)
-      if (AttacksToSquare(board, i, OccBB(BOTH)) & OccBB(board->xstm))
-        return 0;
-
-    return 1;
-  }
-
-  if (PieceType(Moving(move)) == KING)
-    return !(AttacksToSquare(board, to, OccBB(BOTH) ^ PieceBB(KING, board->stm)) & OccBB(board->xstm));
 
   return !GetBit(board->pinned, from) || GetBit(PinnedMoves(from, kingSq), to);
 }

--- a/src/board.h
+++ b/src/board.h
@@ -45,6 +45,7 @@ void BoardToFen(char* fen, Board* board);
 void PrintBoard(Board* board);
 
 void SetSpecialPieces(Board* board);
+void SetThreatsAndEasyCaptures(Board* board);
 
 int DoesMoveCheck(Move move, Board* board);
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -39,56 +39,6 @@ void SetContempt(int* dest, int stm) {
   dest[stm ^ 1] = -contempt;
 }
 
-// "Threats" logic to be utilized in search
-// idea originating in Koivisto
-void Threats(Threat* threats, Board* board, int stm) {
-  int xstm     = stm ^ 1;
-  threats->pcs = threats->sqs = 0;
-
-  BitBoard opponentPieces = OccBB(xstm) ^ PieceBB(PAWN, xstm);
-
-  BitBoard pawnAttacks = stm == WHITE ? ShiftNW(PieceBB(PAWN, WHITE)) | ShiftNE(PieceBB(PAWN, WHITE)) :
-                                        ShiftSW(PieceBB(PAWN, BLACK)) | ShiftSE(PieceBB(PAWN, BLACK));
-  threats->sqs |= pawnAttacks;
-  threats->pcs |= pawnAttacks & opponentPieces;
-
-  // remove minors
-  opponentPieces ^= PieceBB(KNIGHT, xstm) | PieceBB(BISHOP, xstm);
-
-  BitBoard knights = PieceBB(KNIGHT, stm);
-  while (knights) {
-    BitBoard atx = GetKnightAttacks(PopLSB(&knights));
-
-    threats->sqs |= atx;
-    threats->pcs |= opponentPieces & atx;
-  }
-
-  BitBoard bishops = PieceBB(BISHOP, stm);
-  while (bishops) {
-    BitBoard atx = GetBishopAttacks(PopLSB(&bishops), OccBB(BOTH));
-
-    threats->sqs |= atx;
-    threats->pcs |= opponentPieces & atx;
-  }
-
-  // remove rooks
-  opponentPieces ^= PieceBB(ROOK, xstm);
-
-  BitBoard rooks = PieceBB(ROOK, stm);
-  while (rooks) {
-    BitBoard atx = GetRookAttacks(PopLSB(&rooks), OccBB(BOTH));
-
-    threats->sqs |= atx;
-    threats->pcs |= opponentPieces & atx;
-  }
-
-  BitBoard queens = PieceBB(QUEEN, stm);
-  while (queens)
-    threats->sqs |= GetQueenAttacks(PopLSB(&queens), OccBB(BOTH));
-
-  threats->sqs |= GetKingAttacks(LSB(PieceBB(KING, stm)));
-}
-
 // Main evalution method
 Score Evaluate(Board* board, ThreadData* thread) {
   Score knownEval = EvaluateKnownPositions(board);

--- a/src/eval.h
+++ b/src/eval.h
@@ -25,7 +25,6 @@ extern const int PHASE_VALUES[6];
 extern const int MAX_PHASE;
 
 void SetContempt(int* dest, int stm);
-void Threats(Threat* threats, Board* board, int stm);
 Score Evaluate(Board* board, ThreadData* thread);
 void EvaluateTrace(Board* board);
 

--- a/src/history.c
+++ b/src/history.c
@@ -59,12 +59,11 @@ void UpdateHistories(SearchStack* ss,
                      int nC) {
   Board* board     = &thread->board;
   int stm          = board->stm;
-  BitBoard threats = ss->oppThreat.sqs;
 
   int16_t inc = Min(1896, 4 * depth * depth + 120 * depth - 120);
 
   if (!IsCap(bestMove)) {
-    AddHistoryHeuristic(&HH(stm, bestMove, threats), inc);
+    AddHistoryHeuristic(&HH(stm, bestMove, board->threatened), inc);
     UpdateCH(ss, bestMove, inc);
 
     if (Promo(bestMove) < WHITE_QUEEN) {
@@ -89,7 +88,7 @@ void UpdateHistories(SearchStack* ss,
       if (m == bestMove)
         continue;
 
-      AddHistoryHeuristic(&HH(stm, m, threats), -inc);
+      AddHistoryHeuristic(&HH(stm, m, board->threatened), -inc);
       UpdateCH(ss, m, -inc);
     }
   }

--- a/src/history.h
+++ b/src/history.h
@@ -27,7 +27,7 @@
 #define TH(p, e, c)         (thread->caph[p][e][c])
 
 INLINE int GetQuietHistory(SearchStack* ss, ThreadData* thread, Move move) {
-  return (int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
+  return (int) HH(thread->board.stm, move, thread->board.threatened) + //
          (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
          (int) (*(ss - 2)->ch)[Moving(move)][To(move)] +        //
          (int) (*(ss - 4)->ch)[Moving(move)][To(move)];

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230910
+VERSION  = 20230911
 MAIN_NETWORK = networks/berserk-71bdca2676c4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -194,9 +194,13 @@ INLINE ScoredMove* AddCastles(ScoredMove* moves, Board* board, const int stm) {
 
     int to = CASTLE_MAP[rk][1], rookTo = CASTLE_MAP[rk][2];
 
-    BitBoard between = BetweenSquares(from, to) | BetweenSquares(rookFrom, rookTo) | Bit(to) | Bit(rookTo);
+    BitBoard kingCrossing = BetweenSquares(from, to) | Bit(to);
+    BitBoard rookCrossing = BetweenSquares(rookFrom, rookTo) | Bit(rookTo);
+    BitBoard between      = kingCrossing | rookCrossing;
+
     if (!((OccBB(BOTH) ^ Bit(from) ^ Bit(rookFrom)) & between))
-      moves = AddMove(moves, from, to, Piece(KING, stm), NO_PROMO, CASTLE);
+      if (!(kingCrossing & board->threatened))
+        moves = AddMove(moves, from, to, Piece(KING, stm), NO_PROMO, CASTLE);
   }
 
   return moves;
@@ -218,7 +222,7 @@ INLINE ScoredMove* AddQuietChecks(ScoredMove* moves, Board* board, const int stm
 
 INLINE ScoredMove* AddPseudoLegalMoves(ScoredMove* moves, Board* board, const int type, const int color) {
   if (BitCount(board->checkers) > 1)
-    return AddPieceMoves(moves, ALL, board, color, type, KING);
+    return AddPieceMoves(moves, ~board->threatened, board, color, type, KING);
 
   BitBoard opts =
     !board->checkers ? ALL : BetweenSquares(LSB(PieceBB(KING, color)), LSB(board->checkers)) | board->checkers;
@@ -228,7 +232,7 @@ INLINE ScoredMove* AddPseudoLegalMoves(ScoredMove* moves, Board* board, const in
   moves = AddPieceMoves(moves, opts, board, color, type, BISHOP);
   moves = AddPieceMoves(moves, opts, board, color, type, ROOK);
   moves = AddPieceMoves(moves, opts, board, color, type, QUEEN);
-  moves = AddPieceMoves(moves, ALL, board, color, type, KING);
+  moves = AddPieceMoves(moves, ~board->threatened, board, color, type, KING);
   if ((type & GT_QUIET) && !board->checkers)
     moves = AddCastles(moves, board, color);
 
@@ -238,13 +242,11 @@ INLINE ScoredMove* AddPseudoLegalMoves(ScoredMove* moves, Board* board, const in
 INLINE ScoredMove* AddLegalMoves(ScoredMove* moves, Board* board, const int color) {
   ScoredMove* curr = moves;
   BitBoard pinned  = board->pinned;
-  int king         = LSB(PieceBB(KING, board->stm));
 
   moves = AddPseudoLegalMoves(moves, board, GT_LEGAL, color);
 
   while (curr != moves) {
-    if (((pinned && GetBit(pinned, From(curr->move))) || From(curr->move) == king || IsEP(curr->move)) &&
-        !IsLegal(curr->move, board))
+    if (((pinned && GetBit(pinned, From(curr->move))) || IsEP(curr->move)) && !IsLegal(curr->move, board))
       curr->move = (--moves)->move;
     else
       curr++;

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -51,7 +51,7 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
     Move move = current->move;
 
     if (type == ST_QUIET)
-      current->score = 2 * ((int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
+      current->score = 2 * ((int) HH(thread->board.stm, move, thread->board.threatened) + //
                             (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
                             (int) (*(ss - 2)->ch)[Moving(move)][To(move)]) +       //
                        (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +             //
@@ -64,7 +64,7 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
       if (IsCap(move))
         current->score = 1e7 + SEE_VALUE[IsEP(move) ? PAWN : PieceType(board->squares[To(move)])];
       else
-        current->score = 2 * ((int) HH(thread->board.stm, move, ss->oppThreat.sqs) + //
+        current->score = 2 * ((int) HH(thread->board.stm, move, thread->board.threatened) + //
                               (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
                               (int) (*(ss - 2)->ch)[Moving(move)][To(move)]) +       //
                          (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +             //

--- a/src/search.c
+++ b/src/search.c
@@ -447,10 +447,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   (ss + 1)->killers[1] = NULL_MOVE;
   ss->de               = (ss - 1)->de;
 
-  // Build threats for use search
-  Threats(&ss->oppThreat, board, board->xstm);
-  BitBoard oppThreatPcs = ss->oppThreat.pcs;
-
   // IIR by Ed Schroder
   // http://talkchess.com/forum3/viewtopic.php?f=7&t=74769&sid=64085e3396554f0fba414404445b3120
   if (!(ss->skip || inCheck)) {
@@ -462,7 +458,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
     if (depth <= 8 && !ss->skip && eval < WINNING_ENDGAME && eval >= beta &&
-        eval - 69 * depth + 112 * (improving && !oppThreatPcs) >= beta &&
+        eval - 69 * depth + 112 * (improving && !board->easyCapture) >= beta &&
         (!hashMove || GetHistory(ss, thread, hashMove) > 12288))
       return eval;
 
@@ -480,7 +476,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     if (depth >= 3 && (ss - 1)->move != NULL_MOVE && !ss->skip && eval >= beta &&
         // weiss conditional
         HasNonPawn(board) > (depth > 12)) {
-      int R = 4 + 188 * depth / 1024 + Min(5 * (eval - beta) / 1024, 3) + !oppThreatPcs;
+      int R = 4 + 188 * depth / 1024 + Min(5 * (eval - beta) / 1024, 3) + !board->easyCapture;
       R     = Min(depth, R); // don't go too low
 
       TTPrefetch(KeyAfter(board, NULL_MOVE));
@@ -821,11 +817,8 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
 
   if (!inCheck)
     InitQSMovePicker(&mp, thread, depth >= -1);
-  else {
-    Threats(&ss->oppThreat, board, board->xstm);
-
+  else
     InitQSEvasionsPicker(&mp, ttHit ? tt->move : NULL_MOVE, thread, ss);
-  }
 
   int legalMoves = 0;
 

--- a/src/types.h
+++ b/src/types.h
@@ -62,10 +62,6 @@ typedef struct {
 } AccumulatorKingState;
 
 typedef struct {
-  BitBoard pcs, sqs;
-} Threat;
-
-typedef struct {
   int capture;
   int castling;
   int ep;
@@ -74,6 +70,8 @@ typedef struct {
   uint64_t zobrist;
   BitBoard checkers;
   BitBoard pinned;
+  BitBoard threatened;
+  BitBoard easyCapture;
 } BoardHistory;
 
 typedef struct {
@@ -90,6 +88,10 @@ typedef struct {
 
   BitBoard checkers;     // checking piece squares
   BitBoard pinned;       // pinned pieces
+
+  BitBoard threatened;   // opponent "threatening" these squares
+  BitBoard easyCapture;  // opponent capturing these is a guarantee SEE > 0
+
   uint64_t piecesCounts; // "material key" - pieces left on the board
   uint64_t zobrist;      // zobrist hash of the position
 
@@ -123,7 +125,6 @@ typedef struct {
   int ply, staticEval, de;
   PieceTo* ch;
   Move move, skip;
-  Threat oppThreat;
   Move killers[2];
 } SearchStack;
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -355,11 +355,8 @@ void UCILoop() {
       int depth = atoi(d);
       Bench(depth);
     } else if (!strncmp(in, "threats", 7)) {
-      Threat threats[1];
-      Threats(threats, &board, board.stm);
-
-      PrintBB(threats->pcs);
-      PrintBB(threats->sqs);
+      PrintBB(board.easyCapture);
+      PrintBB(board.threatened);
     } else if (!strncmp(in, "eval", 4)) {
       EvaluateTrace(&board);
     } else if (!strncmp(in, "see ", 4)) {


### PR DESCRIPTION
Bench: 4309182

Threats started mostly as a part of search and history, but also have speed optimizations in move generation. By taking the threatened bit board - castles and king moves can be generated even faster. This showed an approximate 1% speedup locally.

```
               master               |             threatened             |
        mu              sigma       |        mu              sigma       |   Sp(1)/Sp(2)      3*sigma   
------------------------------------+------------------------------------+------------------------------------
       1817488.000             0.000|       1845656.000             0.000|      -1.526 %  +/-  0.000 %
       1823591.500          8631.652|       1844063.000          2252.842|      -1.110 %  +/-  1.767 %
       1822541.000          6368.937|       1844475.667          1746.004|      -1.189 %  +/-  1.315 %
       1822925.750          5256.841|       1844859.250          1618.919|      -1.189 %  +/-  1.074 %
       1823853.400          5002.844|       1845160.400          1555.355|      -1.155 %  +/-  0.958 %
       1824188.333          4549.268|       1845849.833          2187.970|      -1.173 %  +/-  0.868 %
       1822846.857          5462.915|       1845847.429          1997.345|      -1.246 %  +/-  0.979 %
```

ELO   | 1.55 +- 1.67 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 1.34 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 81728 W: 20207 L: 19843 D: 41678
http://chess.grantnet.us/test/33617/

ELO   | 5.91 +- 14.33 (95%)
CONF  | 4.0+0.04s Threads=8 Hash=64MB
GAMES | N: 1000 W: 230 L: 213 D: 557
http://chess.grantnet.us/test/33632/

*Note the OB test should've been a regression, since I knew it was faster, but the bench change needed some validation. SMP was to sanity check the pseudo legal code.*