### PR TITLE
Add defended into Capture History indexing

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -57,8 +57,8 @@ void UpdateHistories(SearchStack* ss,
                      int nQ,
                      Move captures[],
                      int nC) {
-  Board* board     = &thread->board;
-  int stm          = board->stm;
+  Board* board = &thread->board;
+  int stm      = board->stm;
 
   int16_t inc = Min(1896, 4 * depth * depth + 120 * depth - 120);
 
@@ -76,9 +76,10 @@ void UpdateHistories(SearchStack* ss,
   } else {
     int piece    = Moving(bestMove);
     int to       = To(bestMove);
+    int defended = !GetBit(board->threatened, to);
     int captured = IsEP(bestMove) ? PAWN : PieceType(board->squares[to]);
 
-    AddHistoryHeuristic(&TH(piece, to, captured), inc);
+    AddHistoryHeuristic(&TH(piece, to, defended, captured), inc);
   }
 
   // Update quiets
@@ -101,8 +102,9 @@ void UpdateHistories(SearchStack* ss,
 
     int piece    = Moving(m);
     int to       = To(m);
+    int defended = !GetBit(board->threatened, to);
     int captured = IsEP(m) ? PAWN : PieceType(board->squares[to]);
 
-    AddHistoryHeuristic(&TH(piece, to, captured), -inc);
+    AddHistoryHeuristic(&TH(piece, to, defended, captured), -inc);
   }
 }

--- a/src/history.h
+++ b/src/history.h
@@ -24,19 +24,22 @@
 #include "util.h"
 
 #define HH(stm, m, threats) (thread->hh[stm][!GetBit(threats, From(m))][!GetBit(threats, To(m))][FromTo(m)])
-#define TH(p, e, c)         (thread->caph[p][e][c])
+#define TH(p, e, d, c)      (thread->caph[p][e][d][c])
 
 INLINE int GetQuietHistory(SearchStack* ss, ThreadData* thread, Move move) {
   return (int) HH(thread->board.stm, move, thread->board.threatened) + //
-         (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
-         (int) (*(ss - 2)->ch)[Moving(move)][To(move)] +        //
+         (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +               //
+         (int) (*(ss - 2)->ch)[Moving(move)][To(move)] +               //
          (int) (*(ss - 4)->ch)[Moving(move)][To(move)];
 }
 
 INLINE int GetCaptureHistory(ThreadData* thread, Move move) {
   Board* board = &thread->board;
 
-  return TH(Moving(move), To(move), IsEP(move) ? PAWN : PieceType(board->squares[To(move)]));
+  return TH(Moving(move),
+            To(move),
+            !GetBit(board->threatened, To(move)),
+            IsEP(move) ? PAWN : PieceType(board->squares[To(move)]));
 }
 
 INLINE int GetHistory(SearchStack* ss, ThreadData* thread, Move move) {

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230911
+VERSION  = 20230913
 MAIN_NETWORK = networks/berserk-71bdca2676c4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/types.h
+++ b/src/types.h
@@ -184,7 +184,7 @@ struct ThreadData {
   Move counters[12][64];         // counter move butterfly table
   int16_t hh[2][2][2][64 * 64];  // history heuristic butterfly table (stm / threatened)
   int16_t ch[2][12][64][12][64]; // continuation move history table
-  int16_t caph[12][64][7];       // capture history
+  int16_t caph[12][64][2][7];    // capture history (piece - to - defeneded - captured_type)
 
   int action, calls;
   pthread_t nativeThread;


### PR DESCRIPTION
Bench: 4700384

ELO   | 3.72 +- 2.73 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 29576 W: 7207 L: 6890 D: 15479
http://chess.grantnet.us/test/33633/

ELO   | 2.15 +- 1.73 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 70920 W: 16515 L: 16076 D: 38329
http://chess.grantnet.us/test/33636/