### PR TITLE
Remove recapture extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ Below is a list of many chess engine lists throughout the web (*variance in Elo 
 - [Extensions](https://www.chessprogramming.org/Extensions)
   - [Singular](https://www.chessprogramming.org/Singular_Extensions)
   - [Check](https://www.chessprogramming.org/Check_Extensions)
-  - [Recapture](https://www.chessprogramming.org/Recapture_Extensions)
-  - History
 
 ### Evaluation
 

--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230913b
+VERSION  = 20230917
 MAIN_NETWORK = networks/berserk-a1f765e06a78.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/move.c
+++ b/src/move.c
@@ -103,9 +103,3 @@ char* MoveToStr(Move move, Board* board) {
 
   return buffer;
 }
-
-inline int IsRecapture(SearchStack* ss, Move move) {
-  return IsCap(move) &&                                                //
-         ((IsCap((ss - 1)->move) && To((ss - 1)->move) == To(move)) || //
-          (IsCap((ss - 3)->move) && To((ss - 3)->move) == To(move)));
-}

--- a/src/move.h
+++ b/src/move.h
@@ -43,6 +43,5 @@ extern const int CASTLING_ROOK[64];
 
 Move ParseMove(char* moveStr, Board* board);
 char* MoveToStr(Move move, Board* board);
-int IsRecapture(SearchStack* ss, Move move);
 
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -589,7 +589,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // (allows for reductions when doing singular search)
     if (!isRoot && ss->ply < thread->depth * 2) {
       // ttHit is implied for move == hashMove to ever be true
-      if (depth >= 7 && move == hashMove && TTDepth(tt) >= depth - 3 && (TTBound(tt) & BOUND_LOWER) &&
+      if (depth >= 6 && move == hashMove && TTDepth(tt) >= depth - 3 && (TTBound(tt) & BOUND_LOWER) &&
           abs(ttScore) < WINNING_ENDGAME) {
         int sBeta  = Max(ttScore - 5 * depth / 8, -CHECKMATE);
         int sDepth = (depth - 1) / 2;
@@ -613,11 +613,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         else if (ttScore <= alpha)
           extension = -1;
       }
-
-      // re-capture extension - looks for a follow up capture on the same square
-      // as the previous capture
-      else if (isPV && IsRecapture(ss, move))
-        extension = 1;
     }
 
     TTPrefetch(KeyAfter(board, move));


### PR DESCRIPTION
Bench: 4303951

SE base depth decreased to offset the loss in other extension.

ELO   | 0.93 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-2.50, 0.50]
GAMES | N: 47376 W: 11390 L: 11263 D: 24723
http://chess.grantnet.us/test/33705/

ELO   | 6.17 +- 4.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-2.50, 0.50]
GAMES | N: 11272 W: 2700 L: 2500 D: 6072
http://chess.grantnet.us/test/33725/