### PR TITLE
PV depth drop + LMR re-search deeper

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20230919
+VERSION  = 20230925
 MAIN_NETWORK = networks/berserk-1968dc235247.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -711,6 +711,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (score > alpha) {
         bestMove = move;
         alpha    = score;
+
+        if (alpha < beta && score > -TB_WIN_BOUND)
+          depth -= (depth >= 2 && depth <= 10);
       }
 
       // we're failing high


### PR DESCRIPTION
Bench: 3556179

This patch merges two concepts.
- When raising alpha on a PV node, but not producing a fail high, lower depth by 1
- When LMR fails by a significant margin, the research will be extended

These patches both did well at STC, but struggled LTC (both looked yellow) and thus were combined to make 1 known good patch.

ELO   | 4.14 +- 2.96 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 26032 W: 6558 L: 6248 D: 13226
http://chess.grantnet.us/test/33812/

ELO   | 3.65 +- 2.70 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 30880 W: 7657 L: 7333 D: 15890
http://chess.grantnet.us/test/33796/

ELO   | 3.39 +- 2.55 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 34016 W: 8274 L: 7942 D: 17800
http://chess.grantnet.us/test/33838/