### PR TITLE
Reduced depth for LMR ZWS re-search

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20231023
+VERSION  = 20231023b
 MAIN_NETWORK = networks/berserk-1cc33042d30d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -659,6 +659,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       score        = -Negamax(-alpha - 1, -alpha, lmrDepth, 1, thread, &childPv, ss + 1);
 
       if (score > alpha && R > 1) {
+        // Credit to Viz (and lonfom) for the following modification of the zws
+        // re-search depth. They can be found in SF as doDeeperSearch + doShallowerSearch
         newDepth += (score > bestScore + 76);
         newDepth -= (score < bestScore + newDepth);
 

--- a/src/search.c
+++ b/src/search.c
@@ -660,7 +660,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       if (score > alpha && R > 1) {
         newDepth += (score > bestScore + 76);
-        newDepth -= (score <= bestScore + 1);
+        newDepth -= (score < bestScore + newDepth);
 
         if (newDepth - 1 > lmrDepth)
           score = -Negamax(-alpha - 1, -alpha, newDepth - 1, !cutnode, thread, &childPv, ss + 1);

--- a/src/search.c
+++ b/src/search.c
@@ -61,7 +61,7 @@ void InitPruningAndReductionTables() {
     LMP[1][depth] = 2.7002 + 0.9448 * depth * depth;
 
     STATIC_PRUNE[0][depth] = -14.9419 * depth * depth; // quiet move cutoff
-    STATIC_PRUNE[1][depth] = -103.9379 * depth; // capture cutoff
+    STATIC_PRUNE[1][depth] = -103.9379 * depth;        // capture cutoff
   }
 }
 
@@ -279,7 +279,7 @@ void Search(ThreadData* thread) {
       if (thread->previousScore == UNKNOWN)
         searchScoreDiff *= 2, prevScoreDiff = 0;
 
-      double scoreChangeFactor = 0.0995 +                                              //
+      double scoreChangeFactor = 0.0995 +                                           //
                                  0.0286 * searchScoreDiff * (searchScoreDiff > 0) + //
                                  0.0261 * prevScoreDiff * (prevScoreDiff > 0);
       scoreChangeFactor = Max(0.4843, Min(1.4498, scoreChangeFactor));
@@ -655,13 +655,15 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // prevent dropping into QS, extending, or reducing all extensions
       R = Min(depth - 1, Max(R, 1));
 
-      score = -Negamax(-alpha - 1, -alpha, newDepth - R, 1, thread, &childPv, ss + 1);
+      int lmrDepth = newDepth - R;
+      score        = -Negamax(-alpha - 1, -alpha, lmrDepth, 1, thread, &childPv, ss + 1);
 
       if (score > alpha && R > 1) {
         newDepth += (score > bestScore + 76);
         newDepth -= (score <= bestScore + 1);
 
-        score = -Negamax(-alpha - 1, -alpha, newDepth - 1, !cutnode, thread, &childPv, ss + 1);
+        if (newDepth - 1 > lmrDepth)
+          score = -Negamax(-alpha - 1, -alpha, newDepth - 1, !cutnode, thread, &childPv, ss + 1);
       }
     } else if (!isPV || playedMoves > 1) {
       score = -Negamax(-alpha - 1, -alpha, newDepth - 1, !cutnode, thread, &childPv, ss + 1);

--- a/src/search.c
+++ b/src/search.c
@@ -659,6 +659,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       if (score > alpha && R > 1) {
         newDepth += (score > bestScore + 76);
+        newDepth -= (score <= bestScore + 1);
 
         score = -Negamax(-alpha - 1, -alpha, newDepth - 1, !cutnode, thread, &childPv, ss + 1);
       }


### PR DESCRIPTION
Bench: 2628557

Elo   | 5.14 +- 3.20 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.00]
Games | N: 20808 W: 4956 L: 4648 D: 11204
Penta | [141, 2345, 5158, 2585, 175]
http://chess.grantnet.us/test/34108/

Elo   | 3.31 +- 2.71 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.25]
Games | N: 27578 W: 6182 L: 5919 D: 15477
Penta | [34, 3041, 7382, 3292, 40]
http://chess.grantnet.us/test/34113/