### PR TITLE
Unify the R between early lmrDepth and LMR

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 12
+VERSION  = 20231029
 MAIN_NETWORK = networks/berserk-fb675dad41b4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 2806666

Elo   | 2.19 +- 2.50 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 34418 W: 8122 L: 7905 D: 18391
Penta | [214, 3969, 8638, 4162, 226]
http://chess.grantnet.us/test/34214/

Elo   | 1.59 +- 2.29 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.72 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 38504 W: 8525 L: 8349 D: 21630
Penta | [43, 4268, 10470, 4412, 59]
http://chess.grantnet.us/test/34218/