### PR TITLE
Decrease LMR Depth when TT is tactical

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20231031
+VERSION  = 20231102
 MAIN_NETWORK = berserk-fb675dad41b4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -560,6 +560,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     int R = LMR[Min(depth, 63)][Min(legalMoves, 63)];
     R -= history / 8192; // adjust reduction based on historical score
+    R += (IsCap(hashMove) || IsPromo(hashMove)); // increase reduction if hash move is noisy
 
     if (bestScore > -TB_WIN_BOUND) {
       if (!isRoot && legalMoves >= LMP[improving][depth])
@@ -652,10 +653,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       // reduce these special quiets less
       if (killerOrCounter)
         R -= 2;
-
-      // less likely a non-capture is best
-      if (IsCap(hashMove) || IsPromo(hashMove))
-        R++;
 
       // move GAVE check
       if (board->checkers)


### PR DESCRIPTION
Bench: 2845960

Elo   | 1.69 +- 1.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.00]
Games | N: 81654 W: 19208 L: 18810 D: 43636
Penta | [518, 9562, 20284, 9930, 533]
http://chess.grantnet.us/test/34231/

Elo   | 1.11 +- 1.39 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.25 (-2.25, 2.89) [0.00, 2.25]
Games | N: 104266 W: 22925 L: 22593 D: 58748
Penta | [118, 11586, 28396, 11912, 121]
http://chess.grantnet.us/test/34241/