### PR TITLE
Don't update quiet best move history if the move was trivial

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -63,9 +63,6 @@ void UpdateHistories(SearchStack* ss,
   int16_t inc = Min(1896, 4 * depth * depth + 120 * depth - 120);
 
   if (!IsCap(bestMove)) {
-    AddHistoryHeuristic(&HH(stm, bestMove, board->threatened), inc);
-    UpdateCH(ss, bestMove, inc);
-
     if (PromoPT(bestMove) != QUEEN) {
       AddKillerMove(ss, bestMove);
 
@@ -73,6 +70,10 @@ void UpdateHistories(SearchStack* ss,
         AddCounterMove(thread, bestMove, (ss - 1)->move);
     }
 
+    if (nQ > 1 || depth > 3) {
+      AddHistoryHeuristic(&HH(stm, bestMove, board->threatened), inc);
+      UpdateCH(ss, bestMove, inc);
+    }
   } else {
     int piece    = Moving(bestMove);
     int to       = To(bestMove);

--- a/src/history.c
+++ b/src/history.c
@@ -70,6 +70,9 @@ void UpdateHistories(SearchStack* ss,
         AddCounterMove(thread, bestMove, (ss - 1)->move);
     }
 
+    // Only increase the best move history when it
+    // wasn't trivial. This idea was first thought of
+    // by Alayan in Ethereal
     if (nQ > 1 || depth > 3) {
       AddHistoryHeuristic(&HH(stm, bestMove, board->threatened), inc);
       UpdateCH(ss, bestMove, inc);

--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20231102
+VERSION  = 20231102b
 MAIN_NETWORK = berserk-fb675dad41b4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 2673520

Elo   | 2.05 +- 1.85 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.00]
Games | N: 62778 W: 14797 L: 14426 D: 33555
Penta | [395, 7383, 15510, 7658, 443]
http://chess.grantnet.us/test/34272/

Elo   | 8.11 +- 4.49 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.25]
Games | N: 10024 W: 2302 L: 2068 D: 5654
Penta | [9, 1033, 2697, 1261, 12]
http://chess.grantnet.us/test/34278/