### PR TITLE
Allow LMR to reduce into QS + allow @ depth 2

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20231104
+VERSION  = 20231108
 MAIN_NETWORK = berserk-8d34b8587772.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -641,7 +641,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     int newDepth = depth + extension;
 
     // Late move reductions
-    if (depth > 2 && legalMoves > 1 && !(isPV && IsCap(move))) {
+    if (depth > 1 && legalMoves > 1 && !(isPV && IsCap(move))) {
       // increase reduction on non-pv
       if (!ttPv)
         R += 2;
@@ -666,7 +666,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         R += 1 + !IsCap(move);
 
       // prevent dropping into QS, extending, or reducing all extensions
-      R = Min(depth - 1, Max(R, 1));
+      R = Min(newDepth, Max(R, 1));
 
       int lmrDepth = newDepth - R;
       score        = -Negamax(-alpha - 1, -alpha, lmrDepth, 1, thread, &childPv, ss + 1);


### PR DESCRIPTION
Bench: 2542132

Elo   | 5.45 +- 3.34 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.00]
Games | N: 19136 W: 4579 L: 4279 D: 10278
Penta | [107, 2159, 4768, 2395, 139]
http://chess.grantnet.us/test/34331/

Elo   | 1.25 +- 1.39 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.25]
Games | N: 106136 W: 23624 L: 23241 D: 59271
Penta | [109, 11805, 28886, 12130, 138]
http://chess.grantnet.us/test/34333/