### PR TITLE
Utilize per move overhead and format

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -70,8 +70,8 @@ void EvaluateTrace(Board* board) {
   ResetAccumulator(board->accumulators, board, WHITE);
   ResetAccumulator(board->accumulators, board, BLACK);
 
-  int base = Propagate(board->accumulators, board->stm);
-  base = board->stm == WHITE ? base : -base;
+  int base   = Propagate(board->accumulators, board->stm);
+  base       = board->stm == WHITE ? base : -base;
   int scaled = (128 + board->phase) * base / 128;
 
   printf("\nNNUE derived piece values:\n");
@@ -99,12 +99,12 @@ void EvaluateTrace(Board* board) {
         ResetAccumulator(board->accumulators, board, WHITE);
         ResetAccumulator(board->accumulators, board, BLACK);
         int new = Propagate(board->accumulators, board->stm);
-        new = board->stm == WHITE ? new : -new;
+        new     = board->stm == WHITE ? new : -new;
         SetBit(OccBB(BOTH), sq);
 
-        int diff = base - new;
+        int diff       = base - new;
         int normalized = Normalize(diff);
-        int v = abs(normalized);
+        int v          = abs(normalized);
 
         char buffer[6];
         buffer[5] = '\0';

--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20231108b
+VERSION  = 20231109
 MAIN_NETWORK = berserk-8d34b8587772.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/move.h
+++ b/src/move.h
@@ -45,9 +45,9 @@ extern const int CASTLING_ROOK[64];
 #define Moving(move)                      (((int) (move) &0x0f000) >> 12)
 #define Flags(move)                       (((int) (move) &0xf0000) >> 16)
 
-#define IsCap(move)           (!!(Flags(move) & CAPTURE_FLAG))
-#define IsEP(move)            (Flags(move) == EP_FLAG)
-#define IsCas(move)           (Flags(move) == CASTLE_FLAG)
+#define IsCap(move) (!!(Flags(move) & CAPTURE_FLAG))
+#define IsEP(move)  (Flags(move) == EP_FLAG)
+#define IsCas(move) (Flags(move) == CASTLE_FLAG)
 
 #define IsPromo(move)         (!!(Flags(move) & PROMO_FLAG))
 #define PromoPT(move)         ((Flags(move) & 0x3) + KNIGHT)

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -51,10 +51,10 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
     Move move = current->move;
 
     if (type == ST_QUIET)
-      current->score = 2 * ((int) HH(thread->board.stm, move, thread->board.threatened) + //
-                            (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
-                            (int) (*(ss - 2)->ch)[Moving(move)][To(move)]) +       //
-                       (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +             //
+      current->score = (int) HH(thread->board.stm, move, thread->board.threatened) * 2 + //
+                       (int) (*(ss - 1)->ch)[Moving(move)][To(move)] * 2 +               //
+                       (int) (*(ss - 2)->ch)[Moving(move)][To(move)] * 2 +               //
+                       (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +                   //
                        (int) (*(ss - 6)->ch)[Moving(move)][To(move)];
 
     else if (type == ST_CAPTURE)
@@ -64,10 +64,10 @@ void ScoreMoves(MovePicker* picker, Board* board, const int type) {
       if (IsCap(move))
         current->score = 1e7 + SEE_VALUE[IsEP(move) ? PAWN : PieceType(board->squares[To(move)])];
       else
-        current->score = 2 * ((int) HH(thread->board.stm, move, thread->board.threatened) + //
-                              (int) (*(ss - 1)->ch)[Moving(move)][To(move)] +        //
-                              (int) (*(ss - 2)->ch)[Moving(move)][To(move)]) +       //
-                         (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +             //
+        current->score = (int) HH(thread->board.stm, move, thread->board.threatened) * 2 + //
+                         (int) (*(ss - 1)->ch)[Moving(move)][To(move)] * 2 +               //
+                         (int) (*(ss - 2)->ch)[Moving(move)][To(move)] * 2 +               //
+                         (int) (*(ss - 4)->ch)[Moving(move)][To(move)] +                   //
                          (int) (*(ss - 6)->ch)[Moving(move)][To(move)];
     }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -36,7 +36,7 @@ INLINE void InitNormalMovePicker(MovePicker* picker, Move hashMove, ThreadData* 
   picker->killer1  = ss->killers[0];
   picker->killer2  = ss->killers[1];
   if ((ss - 1)->move)
-    picker->counter  = thread->counters[Moving((ss - 1)->move)][To((ss - 1)->move)];
+    picker->counter = thread->counters[Moving((ss - 1)->move)][To((ss - 1)->move)];
   else
     picker->counter = NULL_MOVE;
 
@@ -45,14 +45,14 @@ INLINE void InitNormalMovePicker(MovePicker* picker, Move hashMove, ThreadData* 
 }
 
 INLINE void InitPCMovePicker(MovePicker* picker, ThreadData* thread, int threshold) {
-  picker->phase  = PC_GEN_NOISY_MOVES;
-  picker->thread = thread;
+  picker->phase     = PC_GEN_NOISY_MOVES;
+  picker->thread    = thread;
   picker->seeCutoff = threshold;
 }
 
 INLINE void InitQSMovePicker(MovePicker* picker, ThreadData* thread, int genChecks) {
-  picker->phase  = QS_GEN_NOISY_MOVES;
-  picker->thread = thread;
+  picker->phase     = QS_GEN_NOISY_MOVES;
+  picker->thread    = thread;
   picker->genChecks = genChecks;
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -280,12 +280,8 @@ void Search(ThreadData* thread) {
     // Time Management stuff
     long elapsed = GetTimeMS() - Limits.start;
 
-    // Maximum time exceeded, hard exit
-    if (Limits.timeset && elapsed >= Limits.max) {
-      break;
-    }
     // Soft TM checks
-    else if (Limits.timeset && thread->depth >= 5 && !Threads.stopOnPonderHit) {
+    if (Limits.timeset && thread->depth >= 5 && !Threads.stopOnPonderHit) {
       int sameBestMove       = bestMove == previousBestMove;                    // same move?
       searchStability        = sameBestMove ? Min(10, searchStability + 1) : 0; // increase how stable our best move is
       double stabilityFactor = 1.3658 - 0.0482 * searchStability;

--- a/src/thread.c
+++ b/src/thread.c
@@ -209,7 +209,7 @@ INLINE void InitRootMove(RootMove* rm, Move move) {
 
 void SetupMainThread(Board* board) {
   ThreadData* mainThread = Threads.threads[0];
-  mainThread->calls      = 0;
+  mainThread->calls      = Limits.hitrate;
   mainThread->nodes      = 0;
   mainThread->tbhits     = 0;
   mainThread->nmpMinPly  = 0;
@@ -240,7 +240,7 @@ void SetupOtherThreads(Board* board) {
 
   for (int i = 1; i < Threads.count; i++) {
     ThreadData* thread = Threads.threads[i];
-    thread->calls      = 0;
+    thread->calls      = Limits.hitrate;
     thread->nodes      = 0;
     thread->tbhits     = 0;
     thread->nmpMinPly  = 0;

--- a/src/types.h
+++ b/src/types.h
@@ -86,11 +86,11 @@ typedef struct {
   int epSquare; // en passant square (a8 or 0 is not valid so that marks no
                 // active ep)
 
-  BitBoard checkers;     // checking piece squares
-  BitBoard pinned;       // pinned pieces
+  BitBoard checkers; // checking piece squares
+  BitBoard pinned;   // pinned pieces
 
-  BitBoard threatened;   // opponent "threatening" these squares
-  BitBoard easyCapture;  // opponent capturing these is a guarantee SEE > 0
+  BitBoard threatened;  // opponent "threatening" these squares
+  BitBoard easyCapture; // opponent capturing these is a guarantee SEE > 0
 
   uint64_t piecesCounts; // "material key" - pieces left on the board
   uint64_t zobrist;      // zobrist hash of the position

--- a/src/uci.c
+++ b/src/uci.c
@@ -41,7 +41,7 @@
 
 #define START_FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 
-int MOVE_OVERHEAD  = 300;
+int MOVE_OVERHEAD  = 6;
 int MULTI_PV       = 1;
 int PONDER_ENABLED = 0;
 int CHESS_960      = 0;
@@ -176,15 +176,15 @@ void ParseGo(char* in, Board* board) {
       Limits.timeset = 1;
 
       if (movesToGo == -1) {
-        int total = Max(1, time + 50 * inc - MOVE_OVERHEAD);
+        int total = Max(1, time + 50 * inc - 50 * MOVE_OVERHEAD);
 
         Limits.alloc = Min(time * 0.3784, total * 0.0570);
-        Limits.max   = Min((time - MOVE_OVERHEAD) * 0.7776, Limits.alloc * 5.8320);
+        Limits.max   = Min(time * 0.7776 - MOVE_OVERHEAD, Limits.alloc * 5.8320) - 10;
       } else {
         int total = Max(1, time + movesToGo * inc - MOVE_OVERHEAD);
 
         Limits.alloc = Min(time * 0.9, (0.9 * total) / Max(1, movesToGo / 2.5));
-        Limits.max   = Min((time - MOVE_OVERHEAD) * 0.8, Limits.alloc * 5.5);
+        Limits.max   = Min(time * 0.8 - MOVE_OVERHEAD, Limits.alloc * 5.5) - 10;
       }
     } else {
       // no time control
@@ -260,7 +260,7 @@ void PrintUCIOptions() {
   printf("option name Ponder type check default false\n");
   printf("option name UCI_ShowWDL type check default true\n");
   printf("option name UCI_Chess960 type check default false\n");
-  printf("option name MoveOverhead type spin default 300 min 100 max 10000\n");
+  printf("option name MoveOverhead type spin default 6 min 0 max 10000\n");
   printf("option name Contempt type spin default 0 min -100 max 100\n");
   printf("option name EvalFile type string default <empty>\n");
   printf("uciok\n");
@@ -419,7 +419,7 @@ void UCILoop() {
       TTClear();
       SearchClear();
     } else if (!strncmp(in, "setoption name MoveOverhead value ", 34)) {
-      MOVE_OVERHEAD = Min(10000, Max(100, GetOptionIntValue(in)));
+      MOVE_OVERHEAD = Min(10000, Max(0, GetOptionIntValue(in)));
     } else if (!strncmp(in, "setoption name Contempt value ", 30)) {
       CONTEMPT = Min(100, Max(-100, GetOptionIntValue(in)));
     } else if (!strncmp(in, "setoption name EvalFile value ", 30)) {

--- a/src/util.h
+++ b/src/util.h
@@ -28,7 +28,7 @@
 #define INLINE static inline __attribute__((always_inline))
 
 #define LoadRlx(x) atomic_load_explicit(&(x), memory_order_relaxed)
-#define IncRlx(x) atomic_fetch_add_explicit(&(x), 1, memory_order_relaxed)
+#define IncRlx(x)  atomic_fetch_add_explicit(&(x), 1, memory_order_relaxed)
 
 long GetTimeMS();
 


### PR DESCRIPTION
Bench: 2542136

Migrate from 300ms for a whole game -> 6ms per move. This patch isn't actually worth Elo, the test was really verifying no timeouts occur when Berserk is playing at ~500knps.

Elo   | 7.88 +- 6.72 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 4720 W: 1139 L: 1032 D: 2549
Penta | [13, 420, 1398, 505, 24]
http://chess.grantnet.us/test/34348/