### PR TITLE
Update continuation history after LMR

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -23,32 +23,6 @@
 #include "move.h"
 #include "util.h"
 
-INLINE void AddKillerMove(SearchStack* ss, Move move) {
-  if (ss->killers[0] != move) {
-    ss->killers[1] = ss->killers[0];
-    ss->killers[0] = move;
-  }
-}
-
-INLINE void AddCounterMove(ThreadData* thread, Move move, Move parent) {
-  thread->counters[Moving(parent)][To(parent)] = move;
-}
-
-INLINE void AddHistoryHeuristic(int16_t* entry, int16_t inc) {
-  *entry += inc - *entry * abs(inc) / 16384;
-}
-
-INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
-  if ((ss - 1)->move)
-    AddHistoryHeuristic(&(*(ss - 1)->ch)[Moving(move)][To(move)], bonus);
-  if ((ss - 2)->move)
-    AddHistoryHeuristic(&(*(ss - 2)->ch)[Moving(move)][To(move)], bonus);
-  if ((ss - 4)->move)
-    AddHistoryHeuristic(&(*(ss - 4)->ch)[Moving(move)][To(move)], bonus);
-  if ((ss - 6)->move)
-    AddHistoryHeuristic(&(*(ss - 6)->ch)[Moving(move)][To(move)], bonus);
-}
-
 void UpdateHistories(SearchStack* ss,
                      ThreadData* thread,
                      Move bestMove,
@@ -60,7 +34,7 @@ void UpdateHistories(SearchStack* ss,
   Board* board = &thread->board;
   int stm      = board->stm;
 
-  int16_t inc = Min(1896, 4 * depth * depth + 120 * depth - 120);
+  int16_t inc = HistoryBonus(depth);
 
   if (!IsCap(bestMove)) {
     if (PromoPT(bestMove) != QUEEN) {

--- a/src/history.h
+++ b/src/history.h
@@ -46,6 +46,36 @@ INLINE int GetHistory(SearchStack* ss, ThreadData* thread, Move move) {
   return IsCap(move) ? GetCaptureHistory(thread, move) : GetQuietHistory(ss, thread, move);
 }
 
+INLINE void AddKillerMove(SearchStack* ss, Move move) {
+  if (ss->killers[0] != move) {
+    ss->killers[1] = ss->killers[0];
+    ss->killers[0] = move;
+  }
+}
+
+INLINE void AddCounterMove(ThreadData* thread, Move move, Move parent) {
+  thread->counters[Moving(parent)][To(parent)] = move;
+}
+
+INLINE int16_t HistoryBonus(int depth) {
+  return Min(1896, 4 * depth * depth + 120 * depth - 120);
+}
+
+INLINE void AddHistoryHeuristic(int16_t* entry, int16_t inc) {
+  *entry += inc - *entry * abs(inc) / 16384;
+}
+
+INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
+  if ((ss - 1)->move)
+    AddHistoryHeuristic(&(*(ss - 1)->ch)[Moving(move)][To(move)], bonus);
+  if ((ss - 2)->move)
+    AddHistoryHeuristic(&(*(ss - 2)->ch)[Moving(move)][To(move)], bonus);
+  if ((ss - 4)->move)
+    AddHistoryHeuristic(&(*(ss - 4)->ch)[Moving(move)][To(move)], bonus);
+  if ((ss - 6)->move)
+    AddHistoryHeuristic(&(*(ss - 6)->ch)[Moving(move)][To(move)], bonus);
+}
+
 void UpdateHistories(SearchStack* ss,
                      ThreadData* thread,
                      Move bestMove,

--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20231129
+VERSION  = 20231203
 MAIN_NETWORK = berserk-9122d0e7ea7a.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -689,6 +689,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
         if (newDepth - 1 > lmrDepth)
           score = -Negamax(-alpha - 1, -alpha, newDepth - 1, !cutnode, thread, &childPv, ss + 1);
+
+        int bonus = score <= alpha ? -HistoryBonus(newDepth - 1) : score >= beta ? HistoryBonus(newDepth - 1) : 0;
+        UpdateCH(ss, move, bonus);
       }
     } else if (!isPV || playedMoves > 1) {
       score = -Negamax(-alpha - 1, -alpha, newDepth - 1, !cutnode, thread, &childPv, ss + 1);


### PR DESCRIPTION
Bench: 2509982

Elo   | 1.40 +- 1.40 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.00]
Games | N: 109570 W: 25532 L: 25092 D: 58946
Penta | [590, 12835, 27529, 13207, 624]
http://chess.grantnet.us/test/34625/

Elo   | 2.65 +- 2.36 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.25]
Games | N: 36572 W: 8199 L: 7920 D: 20453
Penta | [25, 4076, 9809, 4347, 29]
http://chess.grantnet.us/test/34628/