### PR TITLE
Average return score from RFP with beta

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20231203
+VERSION  = 20231206
 MAIN_NETWORK = berserk-9122d0e7ea7a.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -470,7 +470,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     if (depth <= 8 && !ss->skip && eval < TB_WIN_BOUND && eval >= beta &&
         eval - 67 * depth + 112 * (improving && !board->easyCapture) >= beta &&
         (!hashMove || GetHistory(ss, thread, hashMove) > 12525))
-      return eval;
+      return (eval + beta) / 2;
 
     // Razoring
     if (depth <= 6 && eval + 252 * depth <= alpha) {


### PR DESCRIPTION
Bench: 2639613

Elo   | 5.76 +- 3.43 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.00]
Games | N: 17970 W: 4244 L: 3946 D: 9780
Penta | [99, 1955, 4576, 2259, 96]
http://chess.grantnet.us/test/34665/

Elo   | 3.90 +- 3.19 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.32 (-2.94, 2.94) [0.00, 2.00]
Games | N: 19892 W: 4457 L: 4234 D: 11201
Penta | [23, 2128, 5418, 2357, 20]
http://chess.grantnet.us/test/34667/