### PR TITLE
Add code to make Berserk compile on Apple Silicon out of the box.

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -24,7 +24,6 @@ endif
 UNAME := $(shell uname -m)
 ifeq ($(UNAME), arm64)
     ARCH = arm64
-    CC = clang
 endif
 
 # Setup arch

--- a/src/makefile
+++ b/src/makefile
@@ -20,6 +20,13 @@ ifeq ($(shell echo "test"), "test")
 	CFLAGS += -static
 endif
 
+# Detecting Apple Silicon (ARM64)
+UNAME := $(shell uname -m)
+ifeq ($(UNAME), arm64)
+    ARCH = arm64
+    CC = clang
+endif
+
 # Setup arch
 ifeq ($(ARCH), )
    ARCH = native
@@ -27,6 +34,8 @@ endif
 
 ifeq ($(ARCH), native)
 	CFLAGS  = $(FLAGS) -march=native
+else ifeq ($(ARCH), arm64)
+	CFLAGS = $(FLAGS) -Wno-unused-function -arch arm64
 else ifeq ($(findstring ssse3, $(ARCH)), ssse3)
 	CFLAGS += -mssse3
 else ifeq ($(findstring avx2, $(ARCH)), avx2)
@@ -112,3 +121,6 @@ download-network:
 	else \
 		echo "Unknown network: $(EVALFILE)"; \
 	fi;
+
+clean:
+	rm -f $(EXE)

--- a/src/nn/accumulator.c
+++ b/src/nn/accumulator.c
@@ -16,10 +16,6 @@
 
 #include "accumulator.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
-#include <immintrin.h>
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/nn/accumulator.c
+++ b/src/nn/accumulator.c
@@ -16,7 +16,10 @@
 
 #include "accumulator.h"
 
+#if defined(__x86_64__) || defined(_M_X64)
 #include <immintrin.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/nn/accumulator.h
+++ b/src/nn/accumulator.h
@@ -17,7 +17,9 @@
 #ifndef ACCUMULATOR_H
 #define ACCUMULATOR_H
 
+#if defined(__x86_64__) || defined(_M_X64)
 #include <immintrin.h>
+#endif
 
 #include "../board.h"
 #include "../types.h"

--- a/src/nn/accumulator.h
+++ b/src/nn/accumulator.h
@@ -17,15 +17,12 @@
 #ifndef ACCUMULATOR_H
 #define ACCUMULATOR_H
 
-#if defined(__x86_64__) || defined(_M_X64)
-#include <immintrin.h>
-#endif
-
 #include "../board.h"
 #include "../types.h"
 #include "../util.h"
 
 #if defined(__AVX512F__) && defined(__AVX512BW__)
+#include <immintrin.h>
 #define UNROLL     512
 #define NUM_REGS   16
 #define regi_t     __m512i
@@ -34,6 +31,7 @@
 #define regi_add   _mm512_add_epi16
 #define regi_store _mm512_store_si512
 #elif defined(__AVX2__)
+#include <immintrin.h>
 #define UNROLL     256
 #define NUM_REGS   16
 #define regi_t     __m256i
@@ -42,6 +40,7 @@
 #define regi_add   _mm256_add_epi16
 #define regi_store _mm256_store_si256
 #elif defined(__SSE2__)
+#include <immintrin.h>
 #define UNROLL     128
 #define NUM_REGS   16
 #define regi_t     __m128i

--- a/src/nn/evaluate.c
+++ b/src/nn/evaluate.c
@@ -16,7 +16,10 @@
 
 #include "evaluate.h"
 
+#if defined(__x86_64__) || defined(_M_X64)
 #include <immintrin.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/nn/evaluate.c
+++ b/src/nn/evaluate.c
@@ -16,10 +16,6 @@
 
 #include "evaluate.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
-#include <immintrin.h>
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -53,6 +49,7 @@ float OUTPUT_BIAS;
 uint16_t LOOKUP_INDICES[256][8] ALIGN;
 
 #if defined(__AVX512F__) && defined(__AVX512BW__)
+#include <immintrin.h>
 INLINE void InputReLU(int8_t* outputs, Accumulator* acc, const int stm) {
   const size_t WIDTH  = sizeof(__m512i) / sizeof(acc_t);
   const size_t CHUNKS = N_HIDDEN / WIDTH;
@@ -74,6 +71,7 @@ INLINE void InputReLU(int8_t* outputs, Accumulator* acc, const int stm) {
   }
 }
 #elif defined(__AVX2__)
+#include <immintrin.h>
 INLINE void InputReLU(int8_t* outputs, Accumulator* acc, const int stm) {
   const size_t WIDTH  = sizeof(__m256i) / sizeof(acc_t);
   const size_t CHUNKS = N_HIDDEN / WIDTH;
@@ -95,6 +93,7 @@ INLINE void InputReLU(int8_t* outputs, Accumulator* acc, const int stm) {
   }
 }
 #elif defined(__SSE2__)
+#include <immintrin.h>
 INLINE void InputReLU(int8_t* outputs, Accumulator* acc, const int stm) {
   const size_t WIDTH  = sizeof(__m128i) / sizeof(acc_t);
   const size_t CHUNKS = N_HIDDEN / WIDTH;


### PR DESCRIPTION
Not optmized yet, the arm64 binary is significantly slower than the x86_64 code.