### PR TITLE
Update evaluation using a rolling average based on similar pawn structures

### DIFF
--- a/src/eval.h
+++ b/src/eval.h
@@ -20,8 +20,13 @@
 #include <stdlib.h>
 
 #include "types.h"
+#include "util.h"
 
 #define EVAL_UNKNOWN 2046
+
+INLINE int ClampEval(int eval) {
+    return Min(EVAL_UNKNOWN - 1, Max(-EVAL_UNKNOWN + 1, eval));
+}
 
 extern const int PHASE_VALUES[6];
 extern const int MAX_PHASE;

--- a/src/history.c
+++ b/src/history.c
@@ -86,3 +86,10 @@ void UpdateHistories(SearchStack* ss,
     AddHistoryHeuristic(&TH(piece, to, defended, captured), -inc);
   }
 }
+
+void UpdatePawnCorrection(int raw, int real, Board* board, ThreadData* thread) {
+  const int16_t correction = Min(30000, Max(-30000, (real - raw) * 256));
+  const int idx = (board->pawnZobrist & PAWN_CORRECTION_MASK);
+
+  thread->pawnCorrection[idx] = (thread->pawnCorrection[idx] * 255 + correction) / 256;
+}

--- a/src/history.c
+++ b/src/history.c
@@ -88,7 +88,7 @@ void UpdateHistories(SearchStack* ss,
 }
 
 void UpdatePawnCorrection(int raw, int real, Board* board, ThreadData* thread) {
-  const int16_t correction = Min(30000, Max(-30000, (real - raw) * 256));
+  const int16_t correction = Min(30000, Max(-30000, (real - raw) * PAWN_CORRECTION_GRAIN));
   const int idx = (board->pawnZobrist & PAWN_CORRECTION_MASK);
 
   thread->pawnCorrection[idx] = (thread->pawnCorrection[idx] * 255 + correction) / 256;

--- a/src/history.h
+++ b/src/history.h
@@ -76,6 +76,10 @@ INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
     AddHistoryHeuristic(&(*(ss - 6)->ch)[Moving(move)][To(move)], bonus);
 }
 
+INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
+  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / PAWN_CORRECTION_GRAIN;
+}
+
 void UpdateHistories(SearchStack* ss,
                      ThreadData* thread,
                      Move bestMove,

--- a/src/history.h
+++ b/src/history.h
@@ -85,4 +85,6 @@ void UpdateHistories(SearchStack* ss,
                      Move captures[],
                      int nC);
 
+void UpdatePawnCorrection(int raw, int real, Board* board, ThreadData* thread);
+
 #endif

--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20240101
+VERSION  = 20240103
 MAIN_NETWORK = berserk-3095fe6f8ce5.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -469,9 +469,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       rawEval = ttEval;
       if (rawEval == EVAL_UNKNOWN)
         rawEval = Evaluate(board, thread);
-      eval = ss->staticEval =
-        Min(EVAL_UNKNOWN - 1,
-            Max(-EVAL_UNKNOWN + 1, rawEval + thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 512));
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2);
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -480,9 +478,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         eval = ttScore;
     } else if (!ss->skip) {
       rawEval = Evaluate(board, thread);
-      eval    = ss->staticEval =
-        Min(EVAL_UNKNOWN - 1,
-            Max(-EVAL_UNKNOWN + 1, rawEval + thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 512));
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2);
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -867,9 +863,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
       rawEval = ttEval;
       if (rawEval == EVAL_UNKNOWN)
         rawEval = Evaluate(board, thread);
-      eval = ss->staticEval =
-        Min(EVAL_UNKNOWN - 1,
-            Max(-EVAL_UNKNOWN + 1, rawEval + thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 512));
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2);
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -878,9 +872,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
         eval = ttScore;
     } else {
       rawEval = Evaluate(board, thread);
-      eval    = ss->staticEval =
-        Min(EVAL_UNKNOWN - 1,
-            Max(-EVAL_UNKNOWN + 1, rawEval + thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 512));
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2);
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);

--- a/src/search.c
+++ b/src/search.c
@@ -374,6 +374,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   int inCheck   = !!board->checkers;
   int improving = 0;
   int eval      = ss->staticEval;
+  int rawEval   = eval;
 
   Move bestMove = NULL_MOVE;
   Move hashMove = NULL_MOVE;
@@ -462,12 +463,15 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   }
 
   if (inCheck) {
-    eval = ss->staticEval = EVAL_UNKNOWN;
+    rawEval = eval = ss->staticEval = EVAL_UNKNOWN;
   } else {
     if (ttHit) {
-      eval = ss->staticEval = ttEval;
-      if (ss->staticEval == EVAL_UNKNOWN)
-        eval = ss->staticEval = Evaluate(board, thread);
+      rawEval = ttEval;
+      if (rawEval == EVAL_UNKNOWN)
+        rawEval = Evaluate(board, thread);
+      eval = ss->staticEval =
+        Min(EVAL_UNKNOWN - 1,
+            Max(-EVAL_UNKNOWN + 1, rawEval + thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 512));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -475,12 +479,15 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (ttScore != UNKNOWN && (ttBound & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
         eval = ttScore;
     } else if (!ss->skip) {
-      eval = ss->staticEval = Evaluate(board, thread);
+      rawEval = Evaluate(board, thread);
+      eval    = ss->staticEval =
+        Min(EVAL_UNKNOWN - 1,
+            Max(-EVAL_UNKNOWN + 1, rawEval + thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 512));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
 
-      TTPut(tt, board->zobrist, -1, UNKNOWN, BOUND_UNKNOWN, NULL_MOVE, ss->ply, ss->staticEval, ttPv);
+      TTPut(tt, board->zobrist, -1, UNKNOWN, BOUND_UNKNOWN, NULL_MOVE, ss->ply, rawEval, ttPv);
     }
 
     // Improving
@@ -799,10 +806,12 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   bestScore = Min(bestScore, maxScore);
 
   // prevent saving when in singular search
-  if (!ss->skip && !(isRoot && thread->multiPV > 0)) {
-    int bound = bestScore >= beta ? BOUND_LOWER : bestScore <= origAlpha ? BOUND_UPPER : BOUND_EXACT;
-    TTPut(tt, board->zobrist, depth, bestScore, bound, bestMove, ss->ply, ss->staticEval, ttPv);
-  }
+  int bound = bestScore >= beta ? BOUND_LOWER : bestScore <= origAlpha ? BOUND_UPPER : BOUND_EXACT;
+  if (!ss->skip && !(isRoot && thread->multiPV > 0))
+    TTPut(tt, board->zobrist, depth, bestScore, bound, bestMove, ss->ply, rawEval, ttPv);
+
+  if (!inCheck && !IsCap(bestMove) && (bound & (bestScore >= rawEval ? BOUND_LOWER : BOUND_UPPER)))
+    UpdatePawnCorrection(rawEval, bestScore, board, thread);
 
   return bestScore;
 }
@@ -816,6 +825,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
   int isPV      = beta - alpha != 1;
   int inCheck   = !!board->checkers;
   int eval      = ss->staticEval;
+  int rawEval   = eval;
 
   Move hashMove = NULL_MOVE;
   Move bestMove = NULL_MOVE;
@@ -851,12 +861,15 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
     return ttScore;
 
   if (inCheck) {
-    eval = ss->staticEval = EVAL_UNKNOWN;
+    rawEval = eval = ss->staticEval = EVAL_UNKNOWN;
   } else {
     if (ttHit) {
-      eval = ss->staticEval = ttEval;
-      if (ss->staticEval == EVAL_UNKNOWN)
-        eval = ss->staticEval = Evaluate(board, thread);
+      rawEval = ttEval;
+      if (rawEval == EVAL_UNKNOWN)
+        rawEval = Evaluate(board, thread);
+      eval = ss->staticEval =
+        Min(EVAL_UNKNOWN - 1,
+            Max(-EVAL_UNKNOWN + 1, rawEval + thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 512));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -864,11 +877,15 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
       if (ttScore != UNKNOWN && (ttBound & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
         eval = ttScore;
     } else {
-      eval = ss->staticEval = Evaluate(board, thread);
+      rawEval = Evaluate(board, thread);
+      eval    = ss->staticEval =
+        Min(EVAL_UNKNOWN - 1,
+            Max(-EVAL_UNKNOWN + 1, rawEval + thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 512));
+
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
 
-      TTPut(tt, board->zobrist, -1, UNKNOWN, BOUND_UNKNOWN, NULL_MOVE, ss->ply, ss->staticEval, ttPv);
+      TTPut(tt, board->zobrist, -1, UNKNOWN, BOUND_UNKNOWN, NULL_MOVE, ss->ply, rawEval, ttPv);
     }
 
     // stand pat
@@ -936,7 +953,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
     return -CHECKMATE + ss->ply;
 
   int bound = bestScore >= beta ? BOUND_LOWER : BOUND_UPPER;
-  TTPut(tt, board->zobrist, 0, bestScore, bound, bestMove, ss->ply, ss->staticEval, ttPv);
+  TTPut(tt, board->zobrist, 0, bestScore, bound, bestMove, ss->ply, rawEval, ttPv);
 
   return bestScore;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -38,6 +38,9 @@
 #define ALIGN_ON 64
 #define ALIGN    __attribute__((aligned(ALIGN_ON)))
 
+#define PAWN_CORRECTION_SIZE 16384
+#define PAWN_CORRECTION_MASK (PAWN_CORRECTION_SIZE - 1)
+
 typedef int Score;
 typedef uint64_t BitBoard;
 typedef uint32_t Move;
@@ -68,6 +71,7 @@ typedef struct {
   int fmr;
   int nullply;
   uint64_t zobrist;
+  uint64_t pawnZobrist;
   BitBoard checkers;
   BitBoard pinned;
   BitBoard threatened;
@@ -94,6 +98,7 @@ typedef struct {
 
   uint64_t piecesCounts; // "material key" - pieces left on the board
   uint64_t zobrist;      // zobrist hash of the position
+  uint64_t pawnZobrist;  // pawn zobrist hash of the position (pawns + stm)
 
   int squares[64];         // piece per square
   BitBoard occupancies[3]; // 0 - white pieces, 1 - black pieces, 2 - both
@@ -187,6 +192,8 @@ struct ThreadData {
   int16_t hh[2][2][2][64 * 64];  // history heuristic butterfly table (stm / threatened)
   int16_t ch[2][12][64][12][64]; // continuation move history table
   int16_t caph[12][64][2][7];    // capture history (piece - to - defeneded - captured_type)
+
+  int16_t pawnCorrection[PAWN_CORRECTION_SIZE];
 
   int action, calls;
   pthread_t nativeThread;

--- a/src/types.h
+++ b/src/types.h
@@ -38,8 +38,9 @@
 #define ALIGN_ON 64
 #define ALIGN    __attribute__((aligned(ALIGN_ON)))
 
-#define PAWN_CORRECTION_SIZE 16384
-#define PAWN_CORRECTION_MASK (PAWN_CORRECTION_SIZE - 1)
+#define PAWN_CORRECTION_GRAIN 256
+#define PAWN_CORRECTION_SIZE  16384
+#define PAWN_CORRECTION_MASK  (PAWN_CORRECTION_SIZE - 1)
 
 typedef int Score;
 typedef uint64_t BitBoard;

--- a/src/zobrist.c
+++ b/src/zobrist.c
@@ -39,7 +39,7 @@ void InitZobristKeys() {
   ZOBRIST_SIDE_KEY = RandomUInt64();
 }
 
-// Generate a Zobirst key for the current board state
+// Generate a Zobrist key for the current board state
 uint64_t Zobrist(Board* board) {
   uint64_t hash = 0ULL;
 
@@ -53,6 +53,23 @@ uint64_t Zobrist(Board* board) {
     hash ^= ZOBRIST_EP_KEYS[board->epSquare];
 
   hash ^= ZOBRIST_CASTLE_KEYS[board->castling];
+
+  if (board->stm)
+    hash ^= ZOBRIST_SIDE_KEY;
+
+  return hash;
+}
+
+
+// Generate a Pawn Zobrist key for the current board state
+uint64_t PawnZobrist(Board* board) {
+  uint64_t hash = 0ULL;
+
+  for (int piece = WHITE_PAWN; piece <= BLACK_PAWN; piece++) {
+    BitBoard pcs = board->pieces[piece];
+    while (pcs)
+      hash ^= ZOBRIST_PIECES[piece][PopLSB(&pcs)];
+  }
 
   if (board->stm)
     hash ^= ZOBRIST_SIDE_KEY;

--- a/src/zobrist.h
+++ b/src/zobrist.h
@@ -29,6 +29,7 @@ extern uint64_t ZOBRIST_SIDE_KEY;
 
 void InitZobristKeys();
 uint64_t Zobrist(Board* board);
+uint64_t PawnZobrist(Board* board);
 
 INLINE uint64_t KeyAfter(Board* board, const Move move) {
   if (!move)


### PR DESCRIPTION
Bench: 2479143

*Idea from Caissa*

This concept indexes a small table of values which are rolling averages of differences between the static evaluation and the final search result. This correction is then applied @ 50% to the static eval on the next pass.

Elo   | 1.02 +- 1.43 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 1.59 (-2.94, 2.94) [0.00, 2.00]
Games | N: 104924 W: 24662 L: 24353 D: 55909
Penta | [627, 12300, 26297, 12613, 625]
http://chess.grantnet.us/test/34924/

Elo   | 4.03 +- 3.46 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.31 (-2.94, 2.94) [0.00, 2.25]
Games | N: 17050 W: 3865 L: 3667 D: 9518
Penta | [19, 1798, 4691, 2000, 17]
http://chess.grantnet.us/test/34927/