### PR TITLE
Utilizing a rolling average score across root moves

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20240103
+VERSION  = 20240110
 MAIN_NETWORK = berserk-3095fe6f8ce5.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -254,7 +254,7 @@ void Search(ThreadData* thread) {
       int beta        = CHECKMATE;
       int delta       = CHECKMATE;
       int searchDepth = thread->depth;
-      int score       = thread->rootMoves[thread->multiPV].previousScore;
+      int score       = thread->rootMoves[thread->multiPV].avgScore;
 
       thread->seldepth = 0;
 
@@ -756,6 +756,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         }
 
       rm->nodes += thread->nodes - startingNodeCount;
+      rm->avgScore = rm->avgScore == -CHECKMATE ? score : (rm->avgScore + score) / 2;
 
       if (playedMoves == 1 || score > alpha) {
         rm->score    = score;

--- a/src/thread.c
+++ b/src/thread.c
@@ -199,7 +199,7 @@ void ThreadsInit() {
 INLINE void InitRootMove(RootMove* rm, Move move) {
   rm->move = move;
 
-  rm->previousScore = rm->score = -CHECKMATE;
+  rm->previousScore = rm->score = rm->avgScore = -CHECKMATE;
 
   rm->pv.moves[0] = move;
   rm->pv.count    = 1;

--- a/src/types.h
+++ b/src/types.h
@@ -157,7 +157,7 @@ typedef struct {
 typedef struct {
   Move move;
   int seldepth;
-  int score, previousScore;
+  int score, previousScore, avgScore;
   uint64_t nodes;
   PV pv;
 } RootMove;


### PR DESCRIPTION
Bench: 2411801

Elo   | 0.81 +- 1.56 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 0.76 (-2.94, 2.94) [0.00, 2.00]
Games | N: 87862 W: 20506 L: 20301 D: 47055
Penta | [479, 10437, 21916, 10598, 501]
http://chess.grantnet.us/test/34946/

Elo   | 0.81 +- 1.42 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 0.90 (-2.94, 2.94) [0.00, 2.50]
Games | N: 102208 W: 22806 L: 22567 D: 56835
Penta | [102, 11503, 27652, 11748, 99]
http://chess.grantnet.us/test/34957/