### PR TITLE
Negatively extend cutnodes on failed SE where the expectation is not to fail high

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20240215
+VERSION  = 20240220
 MAIN_NETWORK = berserk-da85741a5582.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -685,6 +685,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
           return sBeta;
         else if (ttScore >= beta)
           extension = -2 + isPV;
+        else if (cutnode)
+          extension = -2;
         else if (ttScore <= alpha)
           extension = -1;
       }


### PR DESCRIPTION
Bench: 2701446

Elo   | 1.68 +- 1.66 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 2.00]
Games | N: 79138 W: 18945 L: 18562 D: 41631
Penta | [311, 9223, 20107, 9628, 300]
http://chess.grantnet.us/test/35577/

Elo   | 1.60 +- 1.73 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 2.50]
Games | N: 68606 W: 15449 L: 15133 D: 38024
Penta | [56, 7655, 18577, 7947, 68]
http://chess.grantnet.us/test/35583/