### PR TITLE
Average out fail highs in QS

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20240220
+VERSION  = 20240221
 MAIN_NETWORK = berserk-da85741a5582.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -950,6 +950,9 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
   if (!legalMoves && inCheck)
     return -CHECKMATE + ss->ply;
 
+  if (bestScore >= beta && abs(bestScore) < TB_WIN_BOUND)
+      bestScore = (bestScore + beta) / 2;
+
   int bound = bestScore >= beta ? BOUND_LOWER : BOUND_UPPER;
   TTPut(tt, board->zobrist, 0, bestScore, bound, bestMove, ss->ply, rawEval, ttPv);
 


### PR DESCRIPTION
Bench: 2356639

Elo   | 3.57 +- 2.72 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.00]
Games | N: 29550 W: 7152 L: 6848 D: 15550
Penta | [102, 3363, 7552, 3645, 113]
http://chess.grantnet.us/test/35597/

Elo   | 1.00 +- 1.39 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 1.80 (-2.25, 2.89) [0.00, 2.50]
Games | N: 105980 W: 23781 L: 23475 D: 58724
Penta | [105, 11865, 28753, 12153, 114]
http://chess.grantnet.us/test/35604/