### PR TITLE
Update history in QS

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20240224
+VERSION  = 20240225
 MAIN_NETWORK = berserk-e4712455eaf4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 2685109

Elo   | 1.39 +- 1.45 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.00]
Games | N: 103894 W: 24712 L: 24297 D: 54885
Penta | [365, 12171, 26497, 12512, 402]
http://chess.grantnet.us/test/35644/

Elo   | 1.99 +- 2.19 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.55 (-2.25, 2.89) [0.00, 2.50]
Games | N: 42554 W: 9543 L: 9299 D: 23712
Penta | [28, 4690, 11601, 4926, 32]
http://chess.grantnet.us/test/35670/