### PR TITLE
Don't NMP when the opponent has an easy capture

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20240225b
+VERSION  = 20240227
 MAIN_NETWORK = berserk-e4712455eaf4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -532,8 +532,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // threats)
     if (depth >= 4 && (ss - 1)->move != NULL_MOVE && !ss->skip && !opponentHasEasyCapture && eval >= beta &&
         HasNonPawn(board, board->stm) && (ss->ply >= thread->nmpMinPly || board->stm != thread->npmColor)) {
-      int R = 5 + 221 * depth / 1024 + Min(5 * (eval - beta) / 1024, 4) + !opponentHasEasyCapture;
-      R     = Min(depth, R); // don't go too low
+      int R = 6 + 221 * depth / 1024 + Min(5 * (eval - beta) / 1024, 4);
 
       TTPrefetch(KeyAfter(board, NULL_MOVE));
       ss->move = NULL_MOVE;

--- a/src/search.c
+++ b/src/search.c
@@ -530,7 +530,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // i.e. Our position is so good we can give our opponnent a free move and
     // they still can't catch up (this is usually countered by captures or mate
     // threats)
-    if (depth >= 4 && (ss - 1)->move != NULL_MOVE && !ss->skip && eval >= beta && HasNonPawn(board, board->stm) &&
+    if (depth >= 4 && (ss - 1)->move != NULL_MOVE && !ss->skip &&
+        eval >= beta + opponentHasEasyCapture * (600 + 100 * depth) && HasNonPawn(board, board->stm) &&
         (ss->ply >= thread->nmpMinPly || board->stm != thread->npmColor)) {
       int R = 5 + 221 * depth / 1024 + Min(5 * (eval - beta) / 1024, 4) + !opponentHasEasyCapture;
       R     = Min(depth, R); // don't go too low
@@ -963,7 +964,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
     return -CHECKMATE + ss->ply;
 
   if (bestScore >= beta && abs(bestScore) < TB_WIN_BOUND)
-      bestScore = (bestScore + beta) / 2;
+    bestScore = (bestScore + beta) / 2;
 
   int bound = bestScore >= beta ? BOUND_LOWER : BOUND_UPPER;
   TTPut(tt, board->zobrist, 0, bestScore, bound, bestMove, ss->ply, rawEval, ttPv);

--- a/src/search.c
+++ b/src/search.c
@@ -530,9 +530,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // i.e. Our position is so good we can give our opponnent a free move and
     // they still can't catch up (this is usually countered by captures or mate
     // threats)
-    if (depth >= 4 && (ss - 1)->move != NULL_MOVE && !ss->skip &&
-        eval >= beta + opponentHasEasyCapture * (600 + 100 * depth) && HasNonPawn(board, board->stm) &&
-        (ss->ply >= thread->nmpMinPly || board->stm != thread->npmColor)) {
+    if (depth >= 4 && (ss - 1)->move != NULL_MOVE && !ss->skip && !opponentHasEasyCapture && eval >= beta &&
+        HasNonPawn(board, board->stm) && (ss->ply >= thread->nmpMinPly || board->stm != thread->npmColor)) {
       int R = 5 + 221 * depth / 1024 + Min(5 * (eval - beta) / 1024, 4) + !opponentHasEasyCapture;
       R     = Min(depth, R); // don't go too low
 


### PR DESCRIPTION
Bench: 2631386

This is probably not a gainer at LTC, but also certainly not a loser. Merging as it is an improvement at STC + Fixed Nodes which is good for testing and datagen.

Elo   | 4.13 +- 3.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.78 (-2.25, 2.89) [0.00, 2.00]
Games | N: 23830 W: 5701 L: 5418 D: 12711
Penta | [54, 2742, 6078, 2949, 92]
http://chess.grantnet.us/test/35690/

Elo   | 0.55 +- 1.50 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | -0.24 (-2.25, 2.89) [0.00, 2.50]
Games | N: 91674 W: 20385 L: 20241 D: 51048
Penta | [79, 10385, 24775, 10509, 89]
http://chess.grantnet.us/test/35691/