### PR TITLE
Reduce reductions on nodes with a TT Entry Depth equal or higher in depth

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20240227
+VERSION  = 20240229
 MAIN_NETWORK = berserk-e4712455eaf4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -726,6 +726,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       if (cutnode)
         R += 1 + !IsCap(move);
 
+      if (ttDepth >= depth)
+        R--;
+
       // prevent dropping into QS, extending, or reducing all extensions
       R = Min(newDepth, Max(R, 1));
 


### PR DESCRIPTION
Bench: 3175821

Elo   | 2.24 +- 2.20 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.47 (-2.25, 2.89) [0.00, 2.00]
Games | N: 44832 W: 10655 L: 10366 D: 23811
Penta | [163, 5210, 11387, 5487, 169]
http://chess.grantnet.us/test/35735/

Elo   | 3.03 +- 3.27 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.03 (-2.25, 2.89) [0.00, 2.50]
Games | N: 19364 W: 4429 L: 4260 D: 10675
Penta | [11, 2099, 5295, 2264, 13]
http://chess.grantnet.us/test/35738/
