### PR TITLE
Utilize phased static contempt

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -54,11 +54,9 @@ Score Evaluate(Board* board, ThreadData* thread) {
 
   int score = board->stm == WHITE ? Propagate(acc, WHITE) : Propagate(acc, BLACK);
 
-  // static contempt
-  score += thread->contempt[board->stm];
-
   // scaled based on phase [1, 1.5]
   score = (128 + board->phase) * score / 128;
+  score += board->phase * thread->contempt[board->stm] / 64;
 
   return Min(EVAL_UNKNOWN - 1, Max(-EVAL_UNKNOWN + 1, score));
 }

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20240304
+VERSION  = 20240308
 MAIN_NETWORK = berserk-58c701642fa8.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 3267480

Go from 100% to 0% of user specified contempt rather than 150% to 100%. While probably not the greatest test, showed some minor improvement over BlackMarlin on OB

*With Contempt=24*
Elo   | 232.54 +- 3.70 (95%)
Conf  | 10.0+0.10s Threads=1 Hash=8MB
Games | N: 21566 W: 12928 L: 322 D: 8316
Penta | [2, 93, 1697, 5279, 3712]
http://chess.grantnet.us/test/35847/

*Without*
Elo   | 223.13 +- 3.90 (95%)
Conf  | 10.0+0.10s Threads=1 Hash=8MB
Games | N: 18358 W: 10663 L: 265 D: 7430
Penta | [2, 68, 1586, 4576, 2947]
http://chess.grantnet.us/test/35846/

