### PR TITLE
Tweak NMP to have less base reduction + more from depth/eval

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20240309
+VERSION  = 20240311
 MAIN_NETWORK = berserk-d3561c0273c8.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -532,7 +532,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // threats)
     if (depth >= 4 && (ss - 1)->move != NULL_MOVE && !ss->skip && !opponentHasEasyCapture && eval >= beta &&
         HasNonPawn(board, board->stm) && (ss->ply >= thread->nmpMinPly || board->stm != thread->npmColor)) {
-      int R = 6 + 221 * depth / 1024 + Min(5 * (eval - beta) / 1024, 4);
+      int R = 4 + 342 * depth / 1024 + Min(10 * (eval - beta) / 1024, 4);
 
       TTPrefetch(KeyAfter(board, NULL_MOVE));
       ss->move = NULL_MOVE;


### PR DESCRIPTION
Bench: 3171415

Elo   | 0.08 +- 1.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | -1.52 (-2.25, 2.89) [0.00, 2.00]
Games | N: 108592 W: 25587 L: 25562 D: 57443
Penta | [383, 12918, 27708, 12865, 422]
http://chess.grantnet.us/test/35765/

Elo   | 1.89 +- 1.98 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 52858 W: 11989 L: 11702 D: 29167
Penta | [48, 5861, 14321, 6154, 45]
http://chess.grantnet.us/test/35868/