### PR TITLE
Utilize depth when updating pawn correction history

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -87,9 +87,10 @@ void UpdateHistories(SearchStack* ss,
   }
 }
 
-void UpdatePawnCorrection(int raw, int real, Board* board, ThreadData* thread) {
+void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData* thread) {
   const int16_t correction = Min(30000, Max(-30000, (real - raw) * PAWN_CORRECTION_GRAIN));
   const int idx            = (board->pawnZobrist & PAWN_CORRECTION_MASK);
+  const int saveDepth      = Min(16, depth);
 
-  thread->pawnCorrection[idx] = (thread->pawnCorrection[idx] * 255 + correction) / 256;
+  thread->pawnCorrection[idx] = (thread->pawnCorrection[idx] * (256 - saveDepth) + correction * saveDepth) / 256;
 }

--- a/src/history.h
+++ b/src/history.h
@@ -89,6 +89,6 @@ void UpdateHistories(SearchStack* ss,
                      Move captures[],
                      int nC);
 
-void UpdatePawnCorrection(int raw, int real, Board* board, ThreadData* thread);
+void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData* thread);
 
 #endif

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 13
+VERSION  = 20241112
 MAIN_NETWORK = berserk-d43206fe90e4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -817,7 +817,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     TTPut(tt, board->zobrist, depth, bestScore, bound, bestMove, ss->ply, rawEval, ttPv);
 
   if (!inCheck && !IsCap(bestMove) && (bound & (bestScore >= rawEval ? BOUND_LOWER : BOUND_UPPER)))
-    UpdatePawnCorrection(rawEval, bestScore, board, thread);
+    UpdatePawnCorrection(rawEval, bestScore, depth, board, thread);
 
   return bestScore;
 }


### PR DESCRIPTION
Bench: 2818506

```
Elo   | 4.13 +- 2.21 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.00]
Games | N: 25002 W: 6182 L: 5885 D: 12935
Penta | [75, 2834, 6405, 3093, 94]
http://chess.grantnet.us/test/38329/
```

```
Elo   | 3.17 +- 2.02 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 26338 W: 6063 L: 5823 D: 14452
Penta | [23, 2839, 7211, 3067, 29]
http://chess.grantnet.us/test/38330/
```