### PR TITLE
Continuation Correction History

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -88,9 +88,22 @@ void UpdateHistories(SearchStack* ss,
 }
 
 void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData* thread) {
-  const int16_t correction = Min(30000, Max(-30000, (real - raw) * PAWN_CORRECTION_GRAIN));
+  const int16_t correction = Min(30000, Max(-30000, (real - raw) * CORRECTION_GRAIN));
   const int idx            = (board->pawnZobrist & PAWN_CORRECTION_MASK);
   const int saveDepth      = Min(16, depth);
 
   thread->pawnCorrection[idx] = (thread->pawnCorrection[idx] * (256 - saveDepth) + correction * saveDepth) / 256;
+}
+
+void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss, ThreadData* thread) {
+  const Move m1 = (ss - 1)->move;
+  const Move m2 = (ss - 2)->move;
+
+  if (m1 && m2) {
+    const int16_t correction = Min(30000, Max(-30000, (real - raw) * CORRECTION_GRAIN));
+    const int saveDepth      = Min(16, depth);
+
+    int16_t* contCorrection = &thread->contCorrection[Moving(m1)][To(m1)][Moving(m2)][To(m2)];
+    *contCorrection = (*contCorrection * (256 - saveDepth) + correction * saveDepth) / 256;
+  }
 }

--- a/src/history.h
+++ b/src/history.h
@@ -77,7 +77,18 @@ INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
 }
 
 INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
-  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / PAWN_CORRECTION_GRAIN;
+  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / CORRECTION_GRAIN;
+}
+
+INLINE int GetContCorrection(SearchStack* ss, ThreadData* thread) {
+  const Move m1 = (ss - 1)->move;
+  const Move m2 = (ss - 2)->move;
+
+  if (m1 && m2) {
+    return thread->contCorrection[Moving(m1)][To(m1)][Moving(m2)][To(m2)] / CORRECTION_GRAIN;
+  } else {
+    return 0;
+  }
 }
 
 void UpdateHistories(SearchStack* ss,
@@ -90,5 +101,6 @@ void UpdateHistories(SearchStack* ss,
                      int nC);
 
 void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData* thread);
+void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss, ThreadData* thread);
 
 #endif

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20241112
+VERSION  = 20241113
 MAIN_NETWORK = berserk-d43206fe90e4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -468,7 +468,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       rawEval = ttEval;
       if (rawEval == EVAL_UNKNOWN)
         rawEval = Evaluate(board, thread);
-      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2);
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss, thread));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -477,7 +477,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         eval = ttScore;
     } else if (!ss->skip) {
       rawEval = Evaluate(board, thread);
-      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2);
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss, thread));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -816,8 +816,10 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   if (!ss->skip && !(isRoot && thread->multiPV > 0))
     TTPut(tt, board->zobrist, depth, bestScore, bound, bestMove, ss->ply, rawEval, ttPv);
 
-  if (!inCheck && !IsCap(bestMove) && (bound & (bestScore >= rawEval ? BOUND_LOWER : BOUND_UPPER)))
+  if (!inCheck && !IsCap(bestMove) && (bound & (bestScore >= rawEval ? BOUND_LOWER : BOUND_UPPER))) {
     UpdatePawnCorrection(rawEval, bestScore, depth, board, thread);
+    UpdateContCorrection(rawEval, bestScore, depth, ss, thread);
+  }
 
   return bestScore;
 }
@@ -872,7 +874,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
       rawEval = ttEval;
       if (rawEval == EVAL_UNKNOWN)
         rawEval = Evaluate(board, thread);
-      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2);
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss, thread));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -881,7 +883,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
         eval = ttScore;
     } else {
       rawEval = Evaluate(board, thread);
-      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2);
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss, thread));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -1065,6 +1067,7 @@ void SearchClearThread(ThreadData* thread) {
   memset(&thread->ch, 0, sizeof(thread->ch));
   memset(&thread->caph, 0, sizeof(thread->caph));
   memset(&thread->pawnCorrection, 0, sizeof(thread->pawnCorrection));
+  memset(&thread->contCorrection, 0, sizeof(thread->contCorrection));
 
   thread->board.accumulators = thread->accumulators;
   thread->previousScore      = UNKNOWN;

--- a/src/types.h
+++ b/src/types.h
@@ -38,7 +38,8 @@
 #define ALIGN_ON 64
 #define ALIGN    __attribute__((aligned(ALIGN_ON)))
 
-#define PAWN_CORRECTION_GRAIN 256
+#define CORRECTION_GRAIN 256
+
 #define PAWN_CORRECTION_SIZE  131072
 #define PAWN_CORRECTION_MASK  (PAWN_CORRECTION_SIZE - 1)
 
@@ -198,6 +199,7 @@ struct ThreadData {
   int16_t caph[12][64][2][7];    // capture history (piece - to - defeneded - captured_type)
 
   int16_t pawnCorrection[PAWN_CORRECTION_SIZE];
+  int16_t contCorrection[12][64][12][64];
 
   int action, calls;
   pthread_t nativeThread;


### PR DESCRIPTION
Bench: 2996197

```
Elo   | 2.75 +- 1.76 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.00]
Games | N: 41026 W: 9885 L: 9560 D: 21581
Penta | [163, 4762, 10379, 5005, 204]
http://chess.grantnet.us/test/38332/
```
```
Elo   | 5.46 +- 2.82 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 14254 W: 3416 L: 3192 D: 7646
Penta | [19, 1548, 3773, 1764, 23]
http://chess.grantnet.us/test/38335/
```