### PR TITLE
"Opponent Worsening" in RFP

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20241113
+VERSION  = 20241119
 MAIN_NETWORK = berserk-d43206fe90e4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -511,11 +511,12 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   MovePicker mp;
   if (!isPV && !inCheck) {
     const int opponentHasEasyCapture = !!OpponentsEasyCaptures(board);
+    const int opponentDeclining = ss->staticEval + (ss - 1)->staticEval > 1;
 
     // Reverse Futility Pruning
     // i.e. the static eval is so far above beta we prune
     if (depth <= 9 && !ss->skip && eval < TB_WIN_BOUND && eval >= beta &&
-        eval - 70 * depth + 118 * (improving && !opponentHasEasyCapture) >= beta &&
+        eval - 70 * depth + 118 * (improving && !opponentHasEasyCapture) + 25 * opponentDeclining >= beta &&
         (!hashMove || GetHistory(ss, thread, hashMove) > 11800))
       return (eval + beta) / 2;
 


### PR DESCRIPTION
Bench: 2625158

Idea from Stockfish. If the opponents last move decreases the static evaluation of the position for them, then slightly increase the possibility of RFP.

```
Elo   | 1.65 +- 1.24 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.00]
Games | N: 79656 W: 19260 L: 18881 D: 41515
Penta | [257, 9340, 20285, 9659, 287]
http://chess.grantnet.us/test/38374/
```

```
Elo   | 1.11 +- 0.90 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 132546 W: 30745 L: 30323 D: 71478
Penta | [97, 14681, 36303, 15087, 105]
http://chess.grantnet.us/test/38375/
```