### PR TITLE
Migrate continuation correction history onto the Search Stack

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -96,14 +96,11 @@ void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData
 }
 
 void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss, ThreadData* thread) {
-  const Move m1 = (ss - 1)->move;
-  const Move m2 = (ss - 2)->move;
-
-  if (m1 && m2) {
+  if ((ss - 1)->move) {
     const int16_t correction = Min(30000, Max(-30000, (real - raw) * CORRECTION_GRAIN));
     const int saveDepth      = Min(16, depth);
 
-    int16_t* contCorrection = &thread->contCorrection[Moving(m1)][To(m1)][Moving(m2)][To(m2)];
-    *contCorrection = (*contCorrection * (256 - saveDepth) + correction * saveDepth) / 256;
+    int16_t* contCorrection = &(*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)];
+    *contCorrection         = (*contCorrection * (256 - saveDepth) + correction * saveDepth) / 256;
   }
 }

--- a/src/history.c
+++ b/src/history.c
@@ -95,8 +95,8 @@ void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData
   thread->pawnCorrection[idx] = (thread->pawnCorrection[idx] * (256 - saveDepth) + correction * saveDepth) / 256;
 }
 
-void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss, ThreadData* thread) {
-  if ((ss - 1)->move) {
+void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss) {
+  if ((ss - 1)->move && (ss - 2)->move) {
     const int16_t correction = Min(30000, Max(-30000, (real - raw) * CORRECTION_GRAIN));
     const int saveDepth      = Min(16, depth);
 

--- a/src/history.h
+++ b/src/history.h
@@ -81,14 +81,7 @@ INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
 }
 
 INLINE int GetContCorrection(SearchStack* ss, ThreadData* thread) {
-  const Move m1 = (ss - 1)->move;
-  const Move m2 = (ss - 2)->move;
-
-  if (m1 && m2) {
-    return thread->contCorrection[Moving(m1)][To(m1)][Moving(m2)][To(m2)] / CORRECTION_GRAIN;
-  } else {
-    return 0;
-  }
+  return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / CORRECTION_GRAIN;
 }
 
 void UpdateHistories(SearchStack* ss,

--- a/src/history.h
+++ b/src/history.h
@@ -80,7 +80,7 @@ INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
   return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / CORRECTION_GRAIN;
 }
 
-INLINE int GetContCorrection(SearchStack* ss, ThreadData* thread) {
+INLINE int GetContCorrection(SearchStack* ss) {
   return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / CORRECTION_GRAIN;
 }
 
@@ -94,6 +94,6 @@ void UpdateHistories(SearchStack* ss,
                      int nC);
 
 void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData* thread);
-void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss, ThreadData* thread);
+void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss);
 
 #endif

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20241119
+VERSION  = 20250113
 MAIN_NETWORK = berserk-d43206fe90e4.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -470,7 +470,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       rawEval = ttEval;
       if (rawEval == EVAL_UNKNOWN)
         rawEval = Evaluate(board, thread);
-      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss, thread));
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -479,7 +479,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         eval = ttScore;
     } else if (!ss->skip) {
       rawEval = Evaluate(board, thread);
-      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss, thread));
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -824,7 +824,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
   if (!inCheck && !IsCap(bestMove) && (bound & (bestScore >= rawEval ? BOUND_LOWER : BOUND_UPPER))) {
     UpdatePawnCorrection(rawEval, bestScore, depth, board, thread);
-    UpdateContCorrection(rawEval, bestScore, depth, ss, thread);
+    UpdateContCorrection(rawEval, bestScore, depth, ss);
   }
 
   return bestScore;
@@ -880,7 +880,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
       rawEval = ttEval;
       if (rawEval == EVAL_UNKNOWN)
         rawEval = Evaluate(board, thread);
-      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss, thread));
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);
@@ -889,7 +889,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
         eval = ttScore;
     } else {
       rawEval = Evaluate(board, thread);
-      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss, thread));
+      eval = ss->staticEval = ClampEval(rawEval + GetPawnCorrection(board, thread) / 2 + GetContCorrection(ss));
 
       // correct eval on fmr
       eval = AdjustEvalOnFMR(board, eval);

--- a/src/types.h
+++ b/src/types.h
@@ -134,6 +134,7 @@ typedef int16_t PieceTo[12][64];
 typedef struct {
   int ply, staticEval, de;
   PieceTo* ch;
+  PieceTo* cont;
   Move move, skip;
   Move killers[2];
 } SearchStack;


### PR DESCRIPTION
Bench: 2625158

Migrate continuation correction history onto the Search Stack. Mostly non-functional, verified via single STC regression.

```
Elo   | 0.78 +- 1.27 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 66724 W: 15920 L: 15770 D: 35034
Penta | [207, 6875, 19064, 6993, 223]
http://chess.grantnet.us/test/38693/
```

