### PR TITLE
Utilize Gravity for Correction Histories

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -88,19 +88,15 @@ void UpdateHistories(SearchStack* ss,
 }
 
 void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData* thread) {
-  const int16_t correction = Min(30000, Max(-30000, (real - raw) * CORRECTION_GRAIN));
-  const int idx            = (board->pawnZobrist & PAWN_CORRECTION_MASK);
-  const int saveDepth      = Min(16, depth);
-
-  thread->pawnCorrection[idx] = (thread->pawnCorrection[idx] * (256 - saveDepth) + correction * saveDepth) / 256;
+  const int16_t correction = Min(4096, Max(-4096, (real - raw) * depth * 32));
+  int16_t* pawnCorrection = &thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK];
+  AddHistoryHeuristic(pawnCorrection, correction);
 }
 
 void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss) {
   if ((ss - 1)->move && (ss - 2)->move) {
-    const int16_t correction = Min(30000, Max(-30000, (real - raw) * CORRECTION_GRAIN));
-    const int saveDepth      = Min(16, depth);
-
+    const int16_t correction = Min(4096, Max(-4096, (real - raw) * depth * 32));
     int16_t* contCorrection = &(*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)];
-    *contCorrection         = (*contCorrection * (256 - saveDepth) + correction * saveDepth) / 256;
+    AddHistoryHeuristic(contCorrection, correction);
   }
 }

--- a/src/history.c
+++ b/src/history.c
@@ -88,14 +88,14 @@ void UpdateHistories(SearchStack* ss,
 }
 
 void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData* thread) {
-  const int16_t correction = Min(4096, Max(-4096, (real - raw) * depth * 32));
+  const int16_t correction = Min(4096, Max(-4096, 4 * (real - raw) * depth));
   int16_t* pawnCorrection = &thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK];
   AddHistoryHeuristic(pawnCorrection, correction);
 }
 
 void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss) {
   if ((ss - 1)->move && (ss - 2)->move) {
-    const int16_t correction = Min(4096, Max(-4096, (real - raw) * depth * 32));
+    const int16_t correction = Min(4096, Max(-4096, 4 * (real - raw) * depth));
     int16_t* contCorrection = &(*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)];
     AddHistoryHeuristic(contCorrection, correction);
   }

--- a/src/history.h
+++ b/src/history.h
@@ -77,11 +77,11 @@ INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
 }
 
 INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
-  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / CORRECTION_GRAIN;
+  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 128;
 }
 
 INLINE int GetContCorrection(SearchStack* ss) {
-  return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / CORRECTION_GRAIN;
+  return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / 128;
 }
 
 void UpdateHistories(SearchStack* ss,

--- a/src/history.h
+++ b/src/history.h
@@ -77,11 +77,11 @@ INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
 }
 
 INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
-  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 256;
+  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 128;
 }
 
 INLINE int GetContCorrection(SearchStack* ss) {
-  return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / 256;
+  return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / 128;
 }
 
 void UpdateHistories(SearchStack* ss,

--- a/src/history.h
+++ b/src/history.h
@@ -77,11 +77,11 @@ INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
 }
 
 INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
-  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 128;
+  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / 256;
 }
 
 INLINE int GetContCorrection(SearchStack* ss) {
-  return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / 128;
+  return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / 256;
 }
 
 void UpdateHistories(SearchStack* ss,

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20250225
+VERSION  = 20250301
 MAIN_NETWORK = berserk-deb80bf0ba9d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -822,9 +822,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
   if (!ss->skip && !(isRoot && thread->multiPV > 0))
     TTPut(tt, board->zobrist, depth, bestScore, bound, bestMove, ss->ply, rawEval, ttPv);
 
-  if (!inCheck && !IsCap(bestMove) && (bound & (bestScore >= rawEval ? BOUND_LOWER : BOUND_UPPER))) {
-    UpdatePawnCorrection(rawEval, bestScore, depth, board, thread);
-    UpdateContCorrection(rawEval, bestScore, depth, ss);
+  if (!inCheck && !IsCap(bestMove) && (bound & (bestScore >= ss->staticEval ? BOUND_LOWER : BOUND_UPPER))) {
+    UpdatePawnCorrection(ss->staticEval, bestScore, depth, board, thread);
+    UpdateContCorrection(ss->staticEval, bestScore, depth, ss);
   }
 
   return bestScore;


### PR DESCRIPTION
Bench: 2722156

Values written such that maximum values are still ~128.

```
Elo   | 2.70 +- 1.74 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.00]
Games | N: 42208 W: 10382 L: 10054 D: 21772
Penta | [174, 4946, 10544, 5258, 182]
http://chess.grantnet.us/test/38833/

Elo   | 3.42 +- 2.14 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 24784 W: 5746 L: 5502 D: 13536
Penta | [14, 2855, 6424, 3071, 28]
http://chess.grantnet.us/test/38836/
```