### PR TITLE
Correction high reduction if opponents position is holding

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20250301
+VERSION  = 20250307
 MAIN_NETWORK = berserk-deb80bf0ba9d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/types.h
+++ b/src/types.h
@@ -40,8 +40,8 @@
 
 #define CORRECTION_GRAIN 256
 
-#define PAWN_CORRECTION_SIZE  131072
-#define PAWN_CORRECTION_MASK  (PAWN_CORRECTION_SIZE - 1)
+#define PAWN_CORRECTION_SIZE 131072
+#define PAWN_CORRECTION_MASK (PAWN_CORRECTION_SIZE - 1)
 
 typedef int Score;
 typedef uint64_t BitBoard;
@@ -94,7 +94,7 @@ typedef struct {
   BitBoard checkers; // checking piece squares
   BitBoard pinned;   // pinned pieces
 
-  BitBoard threatened;  // opponent "threatening" these squares
+  BitBoard threatened; // opponent "threatening" these squares
   BitBoard threatenedBy[6];
 
   int stm;     // side to move
@@ -133,6 +133,7 @@ typedef int16_t PieceTo[12][64];
 
 typedef struct {
   int ply, staticEval, de;
+  int reduction;
   PieceTo* ch;
   PieceTo* cont;
   Move move, skip;


### PR DESCRIPTION
Bench: 3261804

```
Elo   | 3.94 +- 2.18 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.00]
Games | N: 26992 W: 6656 L: 6350 D: 13986
Penta | [124, 3099, 6744, 3405, 124]
http://chess.grantnet.us/test/38866/
```

```
Elo   | 1.36 +- 1.10 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 93038 W: 21359 L: 20996 D: 50683
Penta | [112, 10649, 24631, 11018, 109]
http://chess.grantnet.us/test/38869/
```