### PR TITLE
Alternate TT replace, prioritizing recent position

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20250307
+VERSION  = 20250307b
 MAIN_NETWORK = berserk-deb80bf0ba9d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -110,8 +110,7 @@ inline TTEntry* TTProbe(uint64_t hash,
 
   for (int i = 0; i < BUCKET_SIZE; i++) {
     if (bucket[i].hash == shortHash || !bucket[i].depth) {
-      bucket[i].agePvBound = (uint8_t) (TT.age | (bucket[i].agePvBound & (PV_MASK | BOUND_MASK)));
-      *hit                 = !!bucket[i].depth;
+      *hit = !!bucket[i].depth;
 
       if (*hit) {
         *hashMove = TTMove(&bucket[i]);
@@ -130,8 +129,7 @@ inline TTEntry* TTProbe(uint64_t hash,
 
   TTEntry* replace = bucket;
   for (int i = 1; i < BUCKET_SIZE; i++)
-    if (replace->depth - ((AGE_CYCLE + TT.age - replace->agePvBound) & AGE_MASK) / 2 >
-        bucket[i].depth - ((AGE_CYCLE + TT.age - bucket[i].agePvBound) & AGE_MASK) / 2)
+    if (replace->depth - TTAge(replace) / 2 > bucket[i].depth - TTAge(bucket + i) / 2)
       replace = &bucket[i];
 
   return replace;
@@ -149,7 +147,7 @@ TTPut(TTEntry* tt, uint64_t hash, int depth, int16_t score, uint8_t bound, Move 
   if (move || shortHash != tt->hash)
     TTStoreMove(tt, move);
 
-  if ((bound == BOUND_EXACT) || shortHash != tt->hash || depth + 4 > TTDepth(tt)) {
+  if ((bound == BOUND_EXACT) || shortHash != tt->hash || depth + 4 > TTDepth(tt) || TTAge(tt)) {
     tt->hash       = shortHash;
     tt->score      = score;
     tt->depth      = (uint8_t) (depth - DEPTH_OFFSET);

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -87,6 +87,10 @@ int TTFull();
 
 #define HASH_MAX ((int) (pow(2, 32) * sizeof(TTBucket) / MEGABYTE))
 
+INLINE int TTAge(TTEntry* e) {
+  return ((AGE_CYCLE + TT.age - e->agePvBound) & AGE_MASK);
+}
+
 INLINE Move TTMove(TTEntry* e) {
   // Lower 20 bits for move
   return (e->evalAndMove & 0xfffff);


### PR DESCRIPTION
Bench: 3261804

```
Elo   | 3.76 +- 2.12 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.00]
Games | N: 27964 W: 6879 L: 6576 D: 14509
Penta | [109, 3161, 7165, 3412, 135]
http://chess.grantnet.us/test/38872/
```

```
Elo   | 5.77 +- 2.88 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 13132 W: 3120 L: 2902 D: 7110
Penta | [10, 1386, 3564, 1588, 18]
http://chess.grantnet.us/test/38876/
```