### PR TITLE
Decrease Malus for quiet moves relative to total search moves

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -62,13 +62,15 @@ void UpdateHistories(SearchStack* ss,
 
   // Update quiets
   if (!IsCap(bestMove)) {
+    const int malus = -inc + 32 * (nQ - 1);
+
     for (int i = 0; i < nQ; i++) {
       Move m = quiets[i];
       if (m == bestMove)
         continue;
 
-      AddHistoryHeuristic(&HH(stm, m, board->threatened), -inc);
-      UpdateCH(ss, m, -inc);
+      AddHistoryHeuristic(&HH(stm, m, board->threatened), malus);
+      UpdateCH(ss, m, malus);
     }
   }
 
@@ -89,14 +91,14 @@ void UpdateHistories(SearchStack* ss,
 
 void UpdatePawnCorrection(int raw, int real, int depth, Board* board, ThreadData* thread) {
   const int16_t correction = Min(4096, Max(-4096, 4 * (real - raw) * depth));
-  int16_t* pawnCorrection = &thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK];
+  int16_t* pawnCorrection  = &thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK];
   AddHistoryHeuristic(pawnCorrection, correction);
 }
 
 void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss) {
   if ((ss - 1)->move && (ss - 2)->move) {
     const int16_t correction = Min(4096, Max(-4096, 4 * (real - raw) * depth));
-    int16_t* contCorrection = &(*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)];
+    int16_t* contCorrection  = &(*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)];
     AddHistoryHeuristic(contCorrection, correction);
   }
 }

--- a/src/history.c
+++ b/src/history.c
@@ -62,7 +62,7 @@ void UpdateHistories(SearchStack* ss,
 
   // Update quiets
   if (!IsCap(bestMove)) {
-    const int malus = -inc + 32 * (nQ - 1);
+    const int malus = Min(0, -inc + 32 * (nQ - 1));
 
     for (int i = 0; i < nQ; i++) {
       Move m = quiets[i];

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20250309
+VERSION  = 20250310
 MAIN_NETWORK = berserk-deb80bf0ba9d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 2644751

```
Elo   | 2.26 +- 1.55 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.00]
Games | N: 52326 W: 12717 L: 12377 D: 27232
Penta | [207, 6104, 13179, 6488, 185]
http://chess.grantnet.us/test/38886/
```

```
Elo   | 2.04 +- 1.53 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 47970 W: 10974 L: 10692 D: 26304
Penta | [40, 5463, 12707, 5725, 50]
http://chess.grantnet.us/test/38889/
```