### PR TITLE
Simplify improving flag to ignore grandparent

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20250310
+VERSION  = 20250312
 MAIN_NETWORK = berserk-deb80bf0ba9d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -489,13 +489,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     }
 
     // Improving
-    if (ss->ply >= 2) {
-      if (ss->ply >= 4 && (ss - 2)->staticEval == EVAL_UNKNOWN) {
-        improving = ss->staticEval > (ss - 4)->staticEval || (ss - 4)->staticEval == EVAL_UNKNOWN;
-      } else {
-        improving = ss->staticEval > (ss - 2)->staticEval || (ss - 2)->staticEval == EVAL_UNKNOWN;
-      }
-    }
+    improving = ss->ply >= 2 && (ss->staticEval > (ss - 2)->staticEval || (ss - 2)->staticEval == EVAL_UNKNOWN);
   }
 
   // reset moves to moves related to 1 additional ply


### PR DESCRIPTION
Bench: 3008986

```
Elo   | 1.49 +- 1.67 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 45120 W: 10949 L: 10755 D: 23416
Penta | [162, 5332, 11405, 5472, 189]
http://chess.grantnet.us/test/38894/
```
```
Elo   | 1.03 +- 1.50 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.00, 0.50]
Games | N: 49018 W: 11200 L: 11055 D: 26763
Penta | [40, 5588, 13117, 5715, 49]
http://chess.grantnet.us/test/38895/
```