### PR TITLE
Continutation Correction History based on opponent prior 2 moves

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -101,4 +101,10 @@ void UpdateContCorrection(int raw, int real, int depth, SearchStack* ss) {
     int16_t* contCorrection  = &(*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)];
     AddHistoryHeuristic(contCorrection, correction);
   }
+
+  if ((ss - 1)->move && (ss - 3)->move) {
+    const int16_t correction = Min(4096, Max(-4096, 4 * (real - raw) * depth));
+    int16_t* contCorrection  = &(*(ss - 3)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)];
+    AddHistoryHeuristic(contCorrection, correction);
+  }
 }

--- a/src/history.h
+++ b/src/history.h
@@ -81,7 +81,9 @@ INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
 }
 
 INLINE int GetContCorrection(SearchStack* ss) {
-  return (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] / 128;
+  return ((*(ss - 3)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)] +
+          3 * (*(ss - 2)->cont)[Moving((ss - 1)->move)][To((ss - 1)->move)]) /
+         512;
 }
 
 void UpdateHistories(SearchStack* ss,

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20250313
+VERSION  = 20250321
 MAIN_NETWORK = berserk-deb80bf0ba9d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG


### PR DESCRIPTION
Bench: 3017545

```
Elo   | 2.44 +- 1.63 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.00]
Games | N: 47382 W: 11549 L: 11216 D: 24617
Penta | [166, 5590, 11866, 5883, 186]
http://chess.grantnet.us/test/38905/
```

```
Elo   | 0.90 +- 0.76 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.40 (-2.25, 2.89) [0.00, 2.50]
Games | N: 192424 W: 43555 L: 43055 D: 105814
Penta | [166, 21930, 51504, 22462, 150]
http://chess.grantnet.us/test/38912/
```