### PR TITLE
Avoid Razoring double counting nodes

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20250321
+VERSION  = 20250518
 MAIN_NETWORK = berserk-deb80bf0ba9d.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -525,6 +525,8 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     // Razoring
     if (depth <= 5 && eval + 214 * depth <= alpha) {
+      DecRlx(thread->nodes);
+
       score = Quiesce(alpha, beta, 0, thread, ss);
       if (score <= alpha)
         return score;

--- a/src/util.h
+++ b/src/util.h
@@ -29,6 +29,7 @@
 
 #define LoadRlx(x) atomic_load_explicit(&(x), memory_order_relaxed)
 #define IncRlx(x)  atomic_fetch_add_explicit(&(x), 1, memory_order_relaxed)
+#define DecRlx(x)  atomic_fetch_sub_explicit(&(x), 1, memory_order_relaxed)
 
 long GetTimeMS();
 


### PR DESCRIPTION
Bench: 2943071

Tested as this historically impacted TM heavily resulting in -4 Elo.

```
Elo   | -0.07 +- 0.78 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 204720 W: 49129 L: 49172 D: 106419
Penta | [819, 24344, 52034, 24387, 776]
http://chess.grantnet.us/test/39217/
```

```
Elo   | 0.17 +- 0.92 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 130074 W: 29388 L: 29325 D: 71361
Penta | [97, 15051, 34684, 15102, 103]
http://chess.grantnet.us/test/39223/
```