### PR TITLE
Align node counting with other engines

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20250606
+VERSION  = 20250622
 MAIN_NETWORK = berserk-9b84c340af7e.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/search.c
+++ b/src/search.c
@@ -524,8 +524,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     // Razoring
     if (depth <= 5 && eval + 146 * depth <= alpha) {
-      DecRlx(thread->nodes);
-
       score = Quiesce(alpha, beta, 0, thread, ss);
       if (score <= alpha)
         return score;

--- a/src/search.c
+++ b/src/search.c
@@ -397,7 +397,6 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // hot exit
     longjmp(thread->exit, 1);
 
-  IncRlx(thread->nodes);
   if (isPV && thread->seldepth < ss->ply + 1)
     thread->seldepth = ss->ply + 1;
 
@@ -583,6 +582,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         ss->move = move;
         ss->ch   = &thread->ch[IsCap(move)][Moving(move)][To(move)];
         ss->cont = &thread->contCorrection[Moving(move)][To(move)];
+        IncRlx(thread->nodes);
         MakeMove(move, board);
 
         // qsearch to quickly check
@@ -705,6 +705,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     ss->move = move;
     ss->ch   = &thread->ch[IsCap(move)][Moving(move)][To(move)];
     ss->cont = &thread->contCorrection[Moving(move)][To(move)];
+    IncRlx(thread->nodes);
     MakeMove(move, board);
 
     // apply extensions
@@ -855,8 +856,6 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
     // hot exit
     longjmp(thread->exit, 1);
 
-  IncRlx(thread->nodes);
-
   // draw check
   if (IsDraw(board, ss->ply))
     return 0;
@@ -954,6 +953,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
     ss->move = move;
     ss->ch   = &thread->ch[IsCap(move)][Moving(move)][To(move)];
     ss->cont = &thread->contCorrection[Moving(move)][To(move)];
+    IncRlx(thread->nodes);
     MakeMove(move, board);
 
     score = -Quiesce(-beta, -alpha, depth - 1, thread, ss + 1);

--- a/src/search.c
+++ b/src/search.c
@@ -541,6 +541,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
       ss->move = NULL_MOVE;
       ss->ch   = &thread->ch[0][WHITE_PAWN][A1];
       ss->cont = &thread->contCorrection[WHITE_PAWN][A1];
+      IncRlx(thread->nodes);
       MakeNullMove(board);
 
       score = -Negamax(-beta, -beta + 1, depth - R, !cutnode, thread, &childPv, ss + 1);


### PR DESCRIPTION
Bench: 2811728

Node counting now aligns with MakeMove calls. Tested due to node count impacts with TM. NMP counts done after testing, but should have minimal impact.

```
Elo   | -0.27 +- 0.58 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 362600 W: 87809 L: 88088 D: 186703
Penta | [1210, 43501, 92126, 43284, 1179]
http://chess.grantnet.us/test/39593/

Elo   | 0.38 +- 1.06 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 97686 W: 22760 L: 22652 D: 52274
Penta | [59, 11303, 26025, 11383, 73]
http://chess.grantnet.us/test/39606/
```