### PR TITLE
refactor: remove setjmp from search

### DIFF
--- a/docs/plans/2026-08-22-remove-setjmp-from-search.md
+++ b/docs/plans/2026-08-22-remove-setjmp-from-search.md
@@ -1,0 +1,170 @@
+---
+ingested: 2026-08-22
+source_type: plan
+author: Claude Agent
+synthesis: done
+---
+
+# Remove `setjmp`/`longjmp` from the Berserk search
+
+> Implemented 2026-08-22. Bench verified bit-identical (2,811,728 nodes @ depth 13).
+
+## Context
+
+Berserk aborted a search (time out, node limit, `stop` command) with a non-local
+jump. `Search()` armed a `jmp_buf` once per iterative-deepening iteration and
+`Negamax`/`Quiesce` fired `longjmp(thread->exit, 1)` from the top of any node.
+
+Three problems:
+
+- **It skipped every pending `UndoMove`.** `thread->board` was left at an
+  arbitrary interior node and `board->accumulators` partway up the NNUE
+  accumulator stack. Two workarounds existed only to paper over this — a FEN
+  reload before the ponder-move probe in `MainSearch`, and a pointer reset at the
+  top of `Search()` — both explicitly commented as jmp-abort mitigations.
+  Instrumenting the pre-change build showed this firing on **56 of 81** aborted
+  searches, with the accumulator pointer off by up to 15 slots.
+- **It was formally undefined behavior.** `Search()` has non-`volatile`
+  automatics (`searchStability`, `previousBestMove`, `scores[]`, `ss`) modified
+  after the `setjmp` and relied upon afterwards, under `-O3 -flto`.
+- **It cost a portability `#if`** — MinGW needs `_setjmp(buf, NULL)`, POSIX needs
+  `setjmp(buf)`.
+
+The standard alternative is one shared atomic stop flag, polled at the top of
+every node, plus an early return immediately after the move is undone that
+discards the untrusted value before it can touch root moves, PV, TT, or history.
+Berserk already had the flag (`Threads.stop`) and already polled in the right
+places; only the unwind mechanism changed.
+
+## What changed
+
+### `CheckLimits` raises `Threads.stop` itself — `src/search.c`
+
+The poll itself now raises the flag, so the unwind condition everywhere else is
+just `LoadRlx(Threads.stop)`; no new `ThreadData` field was needed.
+
+```c
+  long elapsed = GetTimeMS() - Limits.start;
+  if ((Limits.timeset && elapsed >= Limits.max) || //
+      (Limits.nodes && NodesSearched() >= Limits.nodes)) {
+    Threads.stop = 1;
+    return 1;
+  }
+
+  return 0;
+```
+
+### Node-top checks
+
+The predicate and its position are unchanged in both `Negamax` and `Quiesce`;
+only the body became `return 0;` in place of the `longjmp`. The check was kept in
+`Quiesce` — dropping it would change when aborts are detected.
+
+### Unwind checks after every recursive call
+
+`if (LoadRlx(Threads.stop)) return 0;` inserted after the board is restored and
+before any persistent state is read or written, at seven sites: razoring, null
+move, NMP verification, ProbCut, singular, the `Negamax` main move loop, and the
+`Quiesce` move loop.
+
+The main-move-loop entry is the critical one. Placing it after `UndoMove` and
+before the `if (isRoot)` block is what keeps `rootMoves[i].score`/`.pv`/`.nodes`
+holding the last completed iteration's data, and returning from inside the loop
+is what keeps the trailing `TTPut`, `UpdateHistories`, and correction updates
+from ever running with a garbage score.
+
+### Iterative-deepening loop
+
+The `setjmp` block was deleted and replaced with three explicit breaks that
+unwind the aspiration loop, the multiPV loop, and the ID loop in turn. The first
+sits **before** `SortRootMoves(thread, thread->multiPV)`, since the longjmp
+reached neither the sort nor `PrintUCI`.
+
+The checks were deliberately **not** folded into the `while (++thread->depth ...)`
+or `for (thread->multiPV ...)` conditions: that would let the aborted iteration
+fall through into the soft-TM / `PrintUCI` block, which the longjmp skipped.
+`thread->depth` retains the aborted (pre-incremented) depth either way, so thread
+voting via `ThreadValue` is unaffected.
+
+### Removed workarounds
+
+- `#include <setjmp.h>` and `jmp_buf exit;` from `ThreadData` (`src/types.h`)
+- `startFen` / `BoardToFen` capture and the `ParseFen(startFen, board)` reload in
+  `MainSearch`
+- `board->accumulators = thread->accumulators;` at the top of `Search()`
+
+`SearchClearThread`'s copy of that last assignment was left alone — redundant now,
+but out of scope and carrying no misleading comment.
+
+## Deliberate deltas
+
+Both follow from `CheckLimits` raising `Threads.stop`:
+
+1. Helper threads stop at the instant the main thread's poll fires, rather than
+   when `MainSearch` sets `Threads.stop = 1` microseconds later.
+2. `go infinite nodes N` now prints `bestmove` when the node limit is hit instead
+   of parking until a `stop` command arrives. Contradictory-flag edge case.
+
+`go ponder` is unaffected — `CheckLimits` still returns early while
+`Threads.ponder` is set, so no limit can raise the flag during ponder.
+
+Not touched: `Limits.stopped` and `Limits.quit` are pre-existing dead fields,
+zeroed in `ParseGo` and never read.
+
+## Verification performed
+
+- **Bench bit-identical**: `./berserk bench 13` → 2,811,728 nodes, with all 50
+  per-position bestmove/score/node lines matching the pre-change build exactly.
+  `Bench` sets `Limits.hitrate = INT_MAX` and never raises `Threads.stop`, so the
+  abort path is never taken — this proves nothing on the normal search path moved.
+  Confirmed on both the plain and PGO builds.
+- **Unwind invariant**: temporary assertions on `board->zobrist`, `board->histPly`,
+  `board->stm` and `thread->board.accumulators == thread->accumulators` at the end
+  of `MainSearch`. 243 searches across 1/4/8 threads: **0 failures**. The same
+  assertions on the pre-change build: **112 failures**, confirming the test is not
+  vacuous and that the `ParseFen` reload was doing real work.
+- **Abort path coverage**: 81 searches per configuration over `go movetime`
+  (1–300ms), `go wtime/btime` with and without increment, `go nodes` (1, 37, 5000,
+  250000 — `go nodes 1` aborts at the root before any move), `go depth 40` + `stop`,
+  `go infinite` + `stop`, `go ponder` + `ponderhit`, `go ponder` + `stop`,
+  `go mate 3`. Each produced exactly one `bestmove`, and the engine stayed healthy
+  for a following search.
+- **Move legality**: 30 aborted searches across 6 positions; every `bestmove` and
+  `ponder` move validated against `go perft 1` from the relevant position.
+- **Sanitizers**: `-fsanitize=address,undefined -O1` build, full stress suite at 4
+  threads — zero diagnostics.
+- **Multi-threaded** (helper threads only ever observe `Threads.stop`, so this is
+  the path that matters): the unwind assertions were extended to check *every*
+  thread's board, accumulator pointer and root move, not just the main thread.
+  Clean across 2/4/8/16 threads over ~2,400 searches, including 60 `go infinite`
+  runs per config with the `stop` issued at randomized delays from 0.5ms to 250ms
+  (so it lands at the first node, mid-subtree, during aspiration re-searches and
+  during multiPV), MultiPV 2/3/5 with aborts, randomized `ponderhit`/`stop`
+  churn, `setoption Threads` changes between searches, and a 50-ply simulated
+  game at a real time control. No hangs, no missing or duplicated `bestmove`.
+  The full hard suite also passes under ASan/UBSan at 8 and 16 threads.
+- **ThreadSanitizer**: the reported races are compared against a TSan build of the
+  pre-change code rather than read in isolation. Over four runs of each, **every
+  signature present in the new build is also present in the baseline** — the
+  change neither introduces nor removes a race. What TSan finds is all
+  pre-existing: the lockless TT (`TTPut`/`TTProbe`, intentional by design,
+  ~99% of reports), the global `Limits` struct written by the UCI thread
+  in `ParseGo` while the previous search's threads still read it, and the thread
+  pool handshake (`MainSearch` reading `thread->depth` / `rootMoves[0].pv.count` /
+  `idx`). That last one is a real latent bug worth a separate look:
+  `ThreadIdle` writes `thread->action = THREAD_SLEEP` *outside* `thread->mutex`,
+  so `ThreadWaitUntilSleep` establishes no happens-before edge with the helper it
+  just joined. Unrelated to this change and left alone.
+- **Suites**: `tests/perft.sh` and `tests/mate-in-1.sh` pass.
+- **Speed**: PGO `bench 13` nps, 8 samples each. Baseline mean ≈2.20M, new mean
+  ≈2.21M; run-to-run noise spans 2.06–2.32M. No measurable regression from the
+  added branches.
+
+## Known-acceptable residue
+
+`src/search.c` writes one continuation-history update (`UpdateCH`) with an
+untrusted score between the LMR search and its re-search on the abort path. This
+was a deliberate call: the cost is roughly one update per live stack frame, once
+per search, against tables with millions of entries. If an SPRT ever suggests it
+matters, guard it with an `UndoMove` + `return 0` immediately after the LMR
+search.

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20260822
+VERSION  = 20260823
 MAIN_NETWORK = berserk-9b84c340af7e.nn
 EVALFILE = $(MAIN_NETWORK)
 NETWORK_BASE = https://github.com/jhonnold/berserk-networks/releases/download/networks

--- a/src/search.c
+++ b/src/search.c
@@ -74,8 +74,13 @@ INLINE int CheckLimits(ThreadData* thread) {
     return 0;
 
   long elapsed = GetTimeMS() - Limits.start;
-  return (Limits.timeset && elapsed >= Limits.max) || //
-         (Limits.nodes && NodesSearched() >= Limits.nodes);
+  if ((Limits.timeset && elapsed >= Limits.max) || //
+      (Limits.nodes && NodesSearched() >= Limits.nodes)) {
+    Threads.stop = 1;
+    return 1;
+  }
+
+  return 0;
 }
 
 INLINE int AdjustEvalOnFMR(Board* board, int eval) {
@@ -105,9 +110,6 @@ void StartSearch(Board* board, uint8_t ponder) {
 void MainSearch() {
   ThreadData* mainThread = Threads.threads[0];
   Board* board           = &mainThread->board;
-
-  char startFen[128];
-  BoardToFen(startFen, board);
 
   TTUpdate();
 
@@ -190,9 +192,6 @@ void MainSearch() {
     ponderMove = bestThread->rootMoves[0].pv.moves[1];
   else {
     // Pull ponder move from the TT if PV doesn't have one.
-    // We reload the startfen because jmp aborts don't guarantee a rolled back board
-    ParseFen(startFen, board);
-
     MakeMove(bestMove, board);
     int ttHit = 0, ttScore, ttEval, ttDepth, ttBound, ttPv = 0;
     TTProbe(board->zobrist, 0, &ttHit, &ponderMove, &ttScore, &ttEval, &ttDepth, &ttBound, &ttPv);
@@ -214,8 +213,7 @@ void Search(ThreadData* thread) {
   Board* board   = &thread->board;
   int mainThread = !thread->idx;
 
-  thread->depth       = 0;
-  board->accumulators = thread->accumulators; // exit jumps can cause this pointer to not be reset
+  thread->depth = 0;
   ResetAccumulator(board->accumulators, board, WHITE);
   ResetAccumulator(board->accumulators, board, BLACK);
   SetContempt(thread->contempt, board->stm);
@@ -238,14 +236,6 @@ void Search(ThreadData* thread) {
   }
 
   while (++thread->depth < MAX_SEARCH_PLY) {
-#if defined(_WIN32) || defined(_WIN64)
-    if (_setjmp(thread->exit, NULL)) {
-#else
-    if (setjmp(thread->exit)) {
-#endif
-      break;
-    }
-
     if (Limits.depth && mainThread && thread->depth > Limits.depth)
       break;
 
@@ -279,6 +269,10 @@ void Search(ThreadData* thread) {
         // search!
         score = Negamax(alpha, beta, Max(1, searchDepth), 0, thread, &nullPv, ss);
 
+        // the score cannot be trusted, leave the root moves as the last completed iteration
+        if (LoadRlx(Threads.stop))
+          break;
+
         SortRootMoves(thread, thread->multiPV);
 
         if (mainThread && (score <= alpha || score >= beta) && Limits.multiPV == 1 &&
@@ -305,12 +299,18 @@ void Search(ThreadData* thread) {
         delta += 16 * delta / 64;
       }
 
+      if (LoadRlx(Threads.stop))
+        break;
+
       SortRootMoves(thread, 0);
 
       // Print if final multipv or time elapsed
       if (mainThread && (thread->multiPV + 1 == Limits.multiPV || GetTimeMS() - Limits.start >= 2500))
         PrintUCI(thread, -CHECKMATE, CHECKMATE, board);
     }
+
+    if (LoadRlx(Threads.stop))
+      break;
 
     if (!mainThread)
       continue;
@@ -394,8 +394,7 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     return Quiesce(alpha, beta, 0, thread, ss);
 
   if (LoadRlx(Threads.stop) || (!thread->idx && CheckLimits(thread)))
-    // hot exit
-    longjmp(thread->exit, 1);
+    return 0;
 
   if (isPV && thread->seldepth < ss->ply + 1)
     thread->seldepth = ss->ply + 1;
@@ -525,6 +524,10 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
     // Razoring
     if (depth <= 5 && eval + 146 * depth <= alpha) {
       score = Quiesce(alpha, beta, 0, thread, ss);
+
+      if (LoadRlx(Threads.stop))
+        return 0;
+
       if (score <= alpha)
         return score;
     }
@@ -548,6 +551,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
       UndoNullMove(board);
 
+      if (LoadRlx(Threads.stop))
+        return 0;
+
       if (score >= beta) {
         if (score >= TB_WIN_BOUND)
           score = beta;
@@ -561,6 +567,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         Score verify = Negamax(beta - 1, beta, depth - R, 0, thread, pv, ss);
 
         thread->nmpMinPly = 0;
+
+        if (LoadRlx(Threads.stop))
+          return 0;
 
         if (verify >= beta)
           return score;
@@ -592,6 +601,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
           score = -Negamax(-probBeta, -probBeta + 1, depth - 4, !cutnode, thread, pv, ss + 1);
 
         UndoMove(move, board);
+
+        if (LoadRlx(Threads.stop))
+          return 0;
 
         if (score >= probBeta)
           return score;
@@ -677,6 +689,9 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
         ss->skip = move;
         score    = Negamax(sBeta - 1, sBeta, sDepth, cutnode, thread, pv, ss);
         ss->skip = NULL_MOVE;
+
+        if (LoadRlx(Threads.stop))
+          return 0;
 
         // no score failed above sBeta, so this is singular
         if (score < sBeta) {
@@ -768,6 +783,11 @@ int Negamax(int alpha, int beta, int depth, int cutnode, ThreadData* thread, PV*
 
     UndoMove(move, board);
 
+    // if a stop occurred the score cannot be trusted, so return immediately without
+    // updating the best move, pv, root moves, histories or tt
+    if (LoadRlx(Threads.stop))
+      return 0;
+
     if (isRoot) {
       RootMove* rm = thread->rootMoves;
       for (int i = 1; i < thread->numRootMoves; i++)
@@ -852,8 +872,7 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
   Move move     = NULL_MOVE;
 
   if (LoadRlx(Threads.stop) || (!thread->idx && CheckLimits(thread)))
-    // hot exit
-    longjmp(thread->exit, 1);
+    return 0;
 
   // draw check
   if (IsDraw(board, ss->ply))
@@ -958,6 +977,9 @@ int Quiesce(int alpha, int beta, int depth, ThreadData* thread, SearchStack* ss)
     score = -Quiesce(-beta, -alpha, depth - 1, thread, ss + 1);
 
     UndoMove(move, board);
+
+    if (LoadRlx(Threads.stop))
+      return 0;
 
     if (score > -TB_WIN_BOUND)
       skipQuiets = 1;

--- a/src/types.h
+++ b/src/types.h
@@ -20,7 +20,6 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <pthread.h>
-#include <setjmp.h>
 #include <stdatomic.h>
 
 #define MAX_SEARCH_PLY 201 // effective max depth 250
@@ -207,7 +206,6 @@ struct ThreadData {
   pthread_t nativeThread;
   pthread_mutex_t mutex;
   pthread_cond_t sleep;
-  jmp_buf exit;
 };
 
 typedef struct {


### PR DESCRIPTION
Bench: 2811728

```
Elo   | 2.22 +- 1.85 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.94 (-2.25, 2.89) [-2.00, 0.00]
Games | N: 31618 W: 7773 L: 7571 D: 16274
Penta | [76, 3287, 8860, 3531, 55]
https://chess.grantnet.us/test/40825/
```