### PR TITLE
fix(nn): recognise __ARM_NEON so NEON builds on Linux aarch64

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ EXE      = berserk
 SRC      = attacks.c bench.c berserk.c bits.c board.c datagen.c eval.c history.c move.c movegen.c movepick.c perft.c random.c \
 		   search.c see.c tb.c thread.c transposition.c uci.c util.c zobrist.c nn/accumulator.c nn/evaluate.c pyrrhic/tbprobe.c
 CC       = clang
-VERSION  = 20260902
+VERSION  = 20260906
 MAIN_NETWORK = berserk-9b84c340af7e.nn
 EVALFILE = $(MAIN_NETWORK)
 NETWORK_BASE = https://github.com/jhonnold/berserk-networks/releases/download/networks

--- a/src/nn/accumulator.h
+++ b/src/nn/accumulator.h
@@ -53,7 +53,7 @@
 #define regi_sub   _mm_sub_epi16
 #define regi_add   _mm_add_epi16
 #define regi_store _mm_store_si128
-#elif defined(__ARM_NEON__)
+#elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include <arm_neon.h>
 #define UNROLL           128
 #define NUM_REGS         16

--- a/src/nn/evaluate.c
+++ b/src/nn/evaluate.c
@@ -178,7 +178,7 @@ INLINE size_t InputCReLU8(int8_t* outputs, uint16_t* nnz, Accumulator* acc, cons
 
   return count;
 }
-#elif defined(__ARM_NEON__)
+#elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include <arm_neon.h>
 INLINE size_t InputCReLU8(int8_t* outputs, uint16_t* nnz, Accumulator* acc, const int stm) {
   const size_t WIDTH  = 8;
@@ -407,7 +407,7 @@ INLINE void L1Affine(int32_t* dest, int8_t* src, const uint16_t* nnz, const size
   for (i = 0; i < OUT_CC; i++)
     out[i] = _mm_srai_epi32(regs[i], QUANT1_BITS);
 }
-#elif defined(__ARM_NEON__)
+#elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 INLINE void int8x16_add_dpbusd(int32x4_t* acc, int8x16_t a, int8x16_t b) {
   int16x8_t p0 = vmull_s8(vget_low_s8(a), vget_low_s8(b));
   int16x8_t p1 = vmull_high_s8(a, b);
@@ -538,7 +538,7 @@ INLINE void L2Affine(int32_t* dest, int16_t* src) {
   for (size_t i = 0; i < OUT_CHUNKS; i++)
     out[i] = _mm_srai_epi32(regs[i], QUANT1_BITS);
 }
-#elif defined(__ARM_NEON__)
+#elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 INLINE void L2Affine(int32_t* dest, int16_t* src) {
   const size_t OUT_WIDTH  = 4;
   const size_t OUT_CHUNKS = N_L3 / OUT_WIDTH;
@@ -634,7 +634,7 @@ INLINE int32_t L3Transform(int16_t* src) {
 
   return _mm_cvtsi128_si32(a1) + OUTPUT_BIAS;
 }
-#elif defined(__ARM_NEON__)
+#elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 INLINE int32_t L3Transform(int16_t* src) {
   const size_t WIDTH  = 8;
   const size_t CHUNKS = N_L3 / WIDTH;
@@ -688,7 +688,7 @@ INLINE void ReLU16(int16_t* dest, int32_t* src, const size_t n) {
     out[i]           = _mm_max_epi16(a0, _mm_setzero_si128());
   }
 }
-#elif defined(__ARM_NEON__)
+#elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 INLINE void ReLU16(int16_t* dest, int32_t* src, const size_t n) {
   const size_t IN_WIDTH = 4;
   const size_t CHUNKS   = n / IN_WIDTH;
@@ -747,7 +747,7 @@ const size_t NETWORK_SIZE = sizeof(int16_t) * N_FEATURES * N_HIDDEN + // input w
                             sizeof(int16_t) * N_L3 +                    // output weights
                             sizeof(int32_t);                            // output bias
 
-#if defined(__SSE4_1__) || defined(__ARM_NEON__)
+#if defined(__SSE4_1__) || defined(__ARM_NEON__) || defined(__ARM_NEON)
 INLINE int WeightIdxScrambled(int idx) {
   return ((idx / SPARSE_CHUNK_SIZE) % (N_L1 / SPARSE_CHUNK_SIZE) * N_L2 * SPARSE_CHUNK_SIZE) +
          (idx / N_L1 * SPARSE_CHUNK_SIZE) + (idx % SPARSE_CHUNK_SIZE);
@@ -792,7 +792,7 @@ INLINE void CopyData(const unsigned char* in) {
   memcpy(l2, &in[offset], N_L2 * N_L3 * sizeof(int16_t));
   offset += N_L2 * N_L3 * sizeof(int16_t);
 
-#if defined(__SSE4_1__) || defined(__ARM_NEON__)
+#if defined(__SSE4_1__) || defined(__ARM_NEON__) || defined(__ARM_NEON)
   for (int i = 0; i < N_L2 * N_L3; i++)
     L2_WEIGHTS[L2WeightIdxScrambled(i)] = l2[i];
 #else
@@ -805,7 +805,7 @@ INLINE void CopyData(const unsigned char* in) {
   offset += N_L3 * N_OUTPUT * sizeof(int16_t);
   memcpy(&OUTPUT_BIAS, &in[offset], sizeof(int32_t));
 
-#if defined(__SSE4_1__) || defined(__ARM_NEON__)
+#if defined(__SSE4_1__) || defined(__ARM_NEON__) || defined(__ARM_NEON)
   // Shuffle the L1 weights for sparse matmul
   for (int i = 0; i < N_L1 * N_L2; i++)
     L1_WEIGHTS[WeightIdxScrambled(i)] = l1[i];


### PR DESCRIPTION
## The problem

The SIMD dispatch in `nn/accumulator.h` and `nn/evaluate.c` guards the NEON path on `__ARM_NEON__`, with trailing underscores. Apple's clang defines that. **On Linux aarch64 neither GCC nor Clang does** — both define `__ARM_NEON`.

Measured on Graviton, Ubuntu 24.04:

```text
gcc 13.3.0    __ARM_NEON: 1   __ARM_NEON__: 0
clang 18.1.3  __ARM_NEON: 1   __ARM_NEON__: 0
```

So every Linux ARM build falls through to the scalar `#else` in `accumulator.h` (`UNROLL 16`, plain `acc_t`) — silently. No error, no warning, roughly half the engine's speed.

Nothing in the makefile catches it either: the ARM64 auto-detect tests `uname -m` against `arm64`, but Linux reports `aarch64`, so `ARCH` stays `native` and `-march=native` compiles the scalar path. (`ARCH=arm64` maps to `-arch arm64`, which is Apple-clang-only, so it is not a usable workaround on Linux.)

This was found while benchmarking AWS Graviton hosts for OpenBench datagen — OpenBench never passes `ARCH=` to the makefile, so its ARM workers get the scalar build too.

## The change

Accept **both** spellings at all 9 guard sites. `__ARM_NEON__` is kept first and unchanged, so Apple Silicon behaviour is untouched; Linux aarch64 now gets the NEON path it already had code for.

10 lines changed across `nn/accumulator.h` (1 site), `nn/evaluate.c` (8 sites), plus the `VERSION` bump.

## Correctness

`bench` reports **2,811,728 nodes** on x86-64 AVX-512, ARM scalar, and ARM NEON alike. Bench is a fixed-depth search, so an identical node count means an identical search tree and therefore identical evaluations at every node — the NEON path is numerically correct, not merely faster.

x86-64 was rebuilt from this branch (`ARCH=avx2`) and is unchanged at 2,811,728 nodes, so there is no regression on the path everyone actually ships.

## Speed

Built from this branch on an AWS `c8g.12xlarge` (Graviton 4, 48 cores), `ARCH=native`, `main` vs this branch:

| | nodes | single-thread nps | 48 concurrent, aggregate |
|---|---|---|---|
| `main` (6db8174) | 2,811,728 | 654,651 | 29,270,018 |
| this branch | 2,811,728 | **1,303,536** | **52,795,738** |
| | | **1.99x** | **1.80x** |

Earlier measurements on two Graviton generations, forcing the define rather than patching, agree:

| | scalar | NEON | speedup |
|---|---|---|---|
| Graviton 2 `m6g.16xlarge` | 372,463 | 666,918 | 1.79x |
| Graviton 4 `c8g.12xlarge` | 688,474 | 1,425,825 | 2.07x |

Both compilers now resolve the patched chain to `PATH=NEON` on aarch64, verified with a preprocessor probe.

## Why it matters beyond ARM enthusiasts

At AWS spot prices this moves a Graviton 4 host from 37% *worse* value than a Zen 4 host to **14% better**, measured as aggregate nodes/sec per dollar-hour with every core busy. For datagen that is a direct cost reduction.

## Not included

The `uname -m` / `ARCH=arm64` makefile issue is left alone — it is a separate change and this fix does not depend on it, since `ARCH=native` now selects NEON correctly on Linux.

https://claude.ai/code/session_01ARJC6rsP7wt21NLnY7yixS